### PR TITLE
TLS13, PSK, and PSK examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 examples/client/client
+examples/client/client-psk
 examples/server/server
+examples/server/server-psk
 examples/aes-encrypt/aes-encrypt
 examples/ecc-sign-verify/ecc-sign-verify
 examples/hash/fileHash

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,21 @@ go build client.go
 
 **NOTE**: Make sure to run both the server and client from within their directories or change the certificate and key paths in the code so that the files are found.
 
+## Building the PSK TLS Server/Client example
+
+A simple TLS 1.3 PSK server/client demonstration. The example `.go` files are located in the `client` and `server` directories. 
+
+To build the server, run :
+```
+go build server-psk.go
+```
+
+To build the client, run :
+```
+go build client-psk.go
+```
+
+
 ## Building the AES encryption example
 
 An application using wolfCrypt AES to encrypt/decrypt files. Located in `aes-encypt` directory.

--- a/examples/client/client-psk.go
+++ b/examples/client/client-psk.go
@@ -1,0 +1,139 @@
+/* client-psk.go
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package main
+
+//#cgo CFLAGS: -g -Wall -I/usr/include 
+//#include <string.h>
+//#include <wolfssl/options.h>
+//#include <wolfssl/ssl.h>
+//#define PSK_KEY_LEN 4
+//unsigned int my_psk_client_cb(WOLFSSL* ssl, const char* hint,
+//        char* identity, unsigned int id_max_len, unsigned char* key,
+//        unsigned int key_max_len)
+//{
+//    (void)ssl;
+//    (void)hint;
+//    (void)key_max_len;
+//
+//    strncpy(identity, "Client_identity", id_max_len);
+//
+//    key[0] = 26;
+//    key[1] = 43;
+//    key[2] = 60;
+//    key[3] = 77;
+//
+//    return PSK_KEY_LEN;
+//}
+import "C"
+import (
+    "net"
+    "os"
+    "fmt"
+    wolfSSL "github.com/wolfssl/go-wolfssl"
+)
+
+/* Connection configuration constants */
+const (
+    CONN_HOST = "localhost"
+    CONN_PORT = "11111"
+    CONN_TYPE = "tcp"
+)
+
+func main() {
+    /* Initialize wolfSSL */
+    wolfSSL.WolfSSL_Init()
+
+    /* Create WOLFSSL_CTX with tlsv12 */
+    ctx := wolfSSL.WolfSSL_CTX_new(wolfSSL.WolfTLSv1_3_client_method())
+    if ctx == nil {
+        fmt.Println(" CTX new Failed");
+        os.Exit(1)
+    }
+
+    wolfSSL.WolfSSL_CTX_set_psk_client_callback(ctx, C.my_psk_client_cb);
+
+    /* Create a WOLFSSL object */
+    ssl := wolfSSL.WolfSSL_new(ctx)
+    if ssl == nil {
+        fmt.Println(" wolfSSL_new failed");
+        os.Exit(1)
+    }
+
+    /* Get address of TCP end point */
+    tcpAddr, err := net.ResolveTCPAddr(CONN_TYPE, CONN_HOST+":"+CONN_PORT)
+    if err != nil {
+        println("ResolveTCPAddr failed:", err.Error())
+        os.Exit(1)
+    }
+
+    /* Dial the recieved TCP address */
+    conn, err := net.DialTCP(CONN_TYPE, nil, tcpAddr)
+    if err != nil {
+        println("Dial failed:", err.Error())
+        os.Exit(1)
+    }
+
+    /* Retrieve file descriptor from net.*TCPConn type */
+    file,err := conn.File()
+    fd := file.Fd()
+    wolfSSL.WolfSSL_set_fd(ssl, int(fd))
+
+    /* Connect to wolfSSL on the server side */
+    ret := wolfSSL.WolfSSL_connect(ssl);
+    if ret != wolfSSL.WOLFSSL_SUCCESS {
+        fmt.Println(" wolfSSL_connect error ", ret);
+        os.Exit(1)
+    } else {
+        fmt.Println("Succesfully Connected!");
+    }
+
+    /* Create the message and send to server */
+    message := []byte("Can you hear me?")
+    sz := uintptr(len(message))
+
+    ret = wolfSSL.WolfSSL_write(ssl, message, sz)
+    if uintptr(ret) != sz {
+        fmt.Println(" wolfSSL_write failed ");
+        os.Exit(1)
+    }
+
+
+    /* Recieve then print the message from server */
+    buf := make([]byte, 256)
+    ret = wolfSSL.WolfSSL_read(ssl, buf, 256)
+    if ret == -1 {
+        fmt.Println(" wolfSSL_read failed ");
+    } else {
+        fmt.Println("Server says : ", string(buf));
+    }
+
+    /* Shutdown wolfSSL */
+    wolfSSL.WolfSSL_shutdown(ssl)
+    /* Free wolfSSL and wolfSSL_CTX objects */
+    wolfSSL.WolfSSL_free(ssl)
+    wolfSSL.WolfSSL_CTX_free(ctx)
+    /* Cleanup the wolfSSL environment */
+    wolfSSL.WolfSSL_Cleanup()
+
+    /* Close the connection */
+    conn.Close()
+}

--- a/examples/server/server-psk.go
+++ b/examples/server/server-psk.go
@@ -74,6 +74,7 @@ func main() {
     ret := wolfSSL.WolfSSL_CTX_use_psk_identity_hint(ctx, "wolfssl server");
     if ret != wolfSSL.WOLFSSL_SUCCESS {
         fmt.Println(" WolfSSL_CTX_use_psk_identity_hint ", ret);
+        fmt.Println(" Ensure wolfSSL is configured with --enable-psk and you've run ./generateOptions.sh");
         os.Exit(1)
     }
     /* Listen for incoming connections */

--- a/examples/server/server-psk.go
+++ b/examples/server/server-psk.go
@@ -1,0 +1,147 @@
+/* server-psk.go
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package main
+
+//#cgo CFLAGS: -g -Wall -I/usr/include
+//#include <string.h>
+//#include <wolfssl/options.h>
+//#include <wolfssl/ssl.h>
+//#define PSK_KEY_LEN 4
+// unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identity,
+//                           unsigned char* key, unsigned int key_max_len)
+//{
+//    (void)ssl;
+//    (void)key_max_len;
+//
+//    if (strncmp(identity, "Client_identity", 15) != 0) {
+//        return 0;
+//    }
+//
+//    key[0] = 26;
+//    key[1] = 43;
+//    key[2] = 60;
+//    key[3] = 77;
+//
+//    return PSK_KEY_LEN;
+//}
+import "C"
+import (
+    "fmt"
+    "net"
+    "os"
+    wolfSSL "github.com/wolfssl/go-wolfssl"
+)
+
+/* Connection configuration constants */
+const (
+    CONN_HOST = "localhost"
+    CONN_PORT = "11111"
+    CONN_TYPE = "tcp"
+)
+
+func main() {
+    /* Initialize wolfSSL */
+    wolfSSL.WolfSSL_Init()
+
+    /* Create WOLFSSL_CTX with tlsv13 */
+    ctx := wolfSSL.WolfSSL_CTX_new(wolfSSL.WolfTLSv1_3_server_method())
+    if ctx == nil {
+        fmt.Println(" WolfSSL_CTX_new Failed");
+        os.Exit(1)
+    }
+
+    wolfSSL.WolfSSL_CTX_set_psk_server_callback(ctx, C.my_psk_server_cb)
+
+    ret := wolfSSL.WolfSSL_CTX_use_psk_identity_hint(ctx, "wolfssl server");
+    if ret != wolfSSL.WOLFSSL_SUCCESS {
+        fmt.Println(" WolfSSL_CTX_use_psk_identity_hint ", ret);
+        os.Exit(1)
+    }
+    /* Listen for incoming connections */
+    l, err := net.Listen(CONN_TYPE, CONN_HOST+":"+CONN_PORT)
+    if err != nil {
+        fmt.Println("Error listening:", err.Error())
+        os.Exit(1)
+    }
+    /* Close the listener when the application closes */
+    defer l.Close()
+    fmt.Println("Listening on " + CONN_HOST + ":" + CONN_PORT)
+
+    /* Listen for an incoming connection */
+    conn, err := l.Accept()
+    if err != nil {
+        fmt.Println("Error accepting: ", err.Error())
+    }
+
+    /* Create a WOLFSSL object */
+    ssl := wolfSSL.WolfSSL_new(ctx)
+    if ssl == nil {
+        fmt.Println(" WolfSSL_new Failed");
+        os.Exit(1)
+    }
+
+    /* Retrieve file descriptor from net.Conn type */
+    file,err := conn.(*net.TCPConn).File()
+    fd := file.Fd()
+    wolfSSL.WolfSSL_set_fd(ssl, int(fd))
+
+    /* Establish TLS connection */
+    ret = wolfSSL.WolfSSL_accept(ssl);
+    if ret != wolfSSL.WOLFSSL_SUCCESS {
+        fmt.Println(" WolfSSL_accept error ", ret);
+        os.Exit(1)
+    } else {
+        fmt.Println("Client Succesfully Connected!");
+    }
+
+    buf := make([]byte, 256)
+
+    /* Recieve then print the message from client */
+    ret = wolfSSL.WolfSSL_read(ssl, buf, 256)
+    if ret == -1 {
+        fmt.Println(" WolfSSL_read failed ");
+    } else {
+        fmt.Println("Client says : ", string(buf));
+    }
+
+    /* Create the message and send to client */
+    reply := []byte("I hear ya fashizzle!")
+    sz := uintptr(len(reply))
+
+    ret = wolfSSL.WolfSSL_write(ssl, reply, sz)
+    if uintptr(ret) != sz {
+        fmt.Println(" WolfSSL_write failed ");
+        os.Exit(1)
+    }
+
+    /* Shutdown wolfSSL */
+    wolfSSL.WolfSSL_shutdown(ssl)
+    /* Free wolfSSL and wolfSSL_CTX objects */
+    wolfSSL.WolfSSL_free(ssl)
+    wolfSSL.WolfSSL_CTX_free(ctx)
+    /* Cleanup the wolfSSL environment */
+    wolfSSL.WolfSSL_Cleanup()
+
+    /* Close the connection */
+    conn.Close()
+}
+

--- a/ssl.go
+++ b/ssl.go
@@ -25,6 +25,14 @@ package wolfSSL
 // #cgo LDFLAGS: -L/usr/local/lib -lwolfssl -lm
 // #include <wolfssl/options.h>
 // #include <wolfssl/ssl.h>
+// #ifdef NO_PSK
+// typedef unsigned int (*pskCb)();
+// int wolfSSL_CTX_use_psk_identity_hint(WOLFSSL_CTX* ctx, const char* hint) {
+//      return -174;
+// }
+// void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX* ctx, pskCb cb) {}
+// void wolfSSL_CTX_set_psk_client_callback(WOLFSSL_CTX* ctx, pskCb cb) {}
+// #endif
 import "C"
 import (
     "unsafe"
@@ -50,6 +58,12 @@ func WolfSSL_CTX_free(ctx *C.struct_WOLFSSL_CTX) {
     C.wolfSSL_CTX_free(ctx)
 }
 
+func WolfSSL_CTX_set_cipher_list(ctx *C.struct_WOLFSSL_CTX, list string) int {
+    c_list := C.CString(list)
+    defer C.free(unsafe.Pointer(c_list))
+    return int(C.wolfSSL_CTX_set_cipher_list(ctx, c_list))
+}
+
 func WolfSSL_new(ctx *C.struct_WOLFSSL_CTX) *C.struct_WOLFSSL {
     return C.wolfSSL_new(ctx)
 }
@@ -72,6 +86,28 @@ func WolfTLSv1_2_server_method() *C.struct_WOLFSSL_METHOD {
 
 func WolfTLSv1_2_client_method() *C.struct_WOLFSSL_METHOD {
     return C.wolfTLSv1_2_client_method()
+}
+
+func WolfTLSv1_3_server_method() *C.struct_WOLFSSL_METHOD {
+    return C.wolfTLSv1_3_server_method()
+}
+
+func WolfTLSv1_3_client_method() *C.struct_WOLFSSL_METHOD {
+    return C.wolfTLSv1_3_client_method()
+}
+
+func WolfSSL_CTX_set_psk_server_callback(ctx *C.struct_WOLFSSL_CTX, cb unsafe.Pointer) {
+    C.wolfSSL_CTX_set_psk_server_callback(ctx, (*[0]byte)(cb))
+}
+
+func WolfSSL_CTX_set_psk_client_callback(ctx *C.struct_WOLFSSL_CTX, cb unsafe.Pointer) {
+    C.wolfSSL_CTX_set_psk_client_callback(ctx, (*[0]byte)(cb))
+}
+
+func WolfSSL_CTX_use_psk_identity_hint(ctx *C.struct_WOLFSSL_CTX, hint string) int {
+    c_hint := C.CString(hint)
+    defer C.free(unsafe.Pointer(c_hint))
+    return int(C.wolfSSL_CTX_use_psk_identity_hint(ctx, c_hint))
 }
 
 func WolfSSL_CTX_load_verify_locations(ctx *C.struct_WOLFSSL_CTX, cert string,


### PR DESCRIPTION
For the callbacks: GO functions cannot be used as C functions and executed from function pointers. So for now, the PSK callbacks have to be written in C. The files `examples/server/server-psk.go` and `examples/client/client-psk.go` show how to do this. There might be a better way to do this but this was the quickest solution. 

zd 16513