### PR TITLE
Functionality required for Wireguard Go

### DIFF
--- a/aes.go
+++ b/aes.go
@@ -22,7 +22,7 @@
 package wolfSSL
 
 // #cgo CFLAGS: -g -Wall -I/usr/include -I/usr/include/wolfssl
-// #cgo LDFLAGS: -L/usr/local/lib -lwolfssl -lm
+// #cgo LDFLAGS: -L/usr/local/lib -lwolfssl
 // #include <wolfssl/options.h>
 // #include <wolfssl/wolfcrypt/aes.h>
 // #include <wolfssl/wolfcrypt/pwdbased.h>

--- a/blake2.go
+++ b/blake2.go
@@ -1,0 +1,128 @@
+/* blake2s.go
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package wolfSSL
+
+// #include <wolfssl/options.h>
+// #include <wolfssl/wolfcrypt/hash.h>
+// #include <wolfssl/wolfcrypt/blake2.h>
+// #ifndef HAVE_BLAKE2S
+// typedef struct Blake2s {} Blake2s;
+// void wc_Blake2s_HMAC(byte *out, const byte *in, const byte *key, word32 outlen, word32 inlen, word32 keylen) {
+//      return;
+// }
+// int wc_InitBlake2s(Blake2s* b, word32 digestSz) {
+//      return -174;
+//  }
+// int wc_InitBlake2s_WithKey(Blake2s* b, word32 digestSz, byte *key, word32 keylen) {
+//      return -174;
+//  }
+// int wc_Blake2sUpdate(Blake2s* b2s, byte* data, word32 sz) {
+//      return -174;
+//  }
+// int wc_Blake2sFinal(Blake2s* b2s, byte* data, word32 reqSz) {
+//      return -174;
+//  }
+// #endif
+import "C"
+import (
+    "unsafe"
+)
+
+const WC_BLAKE2S_256_DIGEST_SIZE = 32
+const WC_BLAKE2S_128_DIGEST_SIZE = 16
+
+const WC_BLAKE2S_256_BLOCK_SIZE = 64
+
+type Blake2s = C.struct_Blake2s
+
+func Wc_InitBlake2s(blake2s *C.struct_Blake2s, digestSz int) int {
+    return int(C.wc_InitBlake2s(blake2s, C.word32(digestSz)))
+}
+
+func Wc_InitBlake2s_WithKey(blake2s *C.struct_Blake2s, digestSz int, key []byte) int {
+    return int(C.wc_InitBlake2s_WithKey(blake2s, C.word32(digestSz),
+               (*C.uchar)(unsafe.Pointer(&key[0])), C.word32(len(key))))
+}
+
+func Wc_Blake2sUpdate(blake2s *C.struct_Blake2s, in []byte, sz int) int {
+    var sanIn *C.uchar
+    if len(in) > 0 {
+        sanIn = (*C.uchar)(unsafe.Pointer(&in[0]))
+    } else {
+        sanIn = (*C.uchar)(unsafe.Pointer(nil))
+    }
+
+    return int(C.wc_Blake2sUpdate(blake2s, sanIn, C.word32(sz)))
+}
+
+func Wc_Blake2sFinal(blake2s *C.struct_Blake2s, out []byte, requestSz int) int {
+    return int(C.wc_Blake2sFinal(blake2s, (*C.uchar)(unsafe.Pointer(&out[0])),
+               C.word32(requestSz)))
+}
+
+func Wc_Blake2s_HMAC(out []byte, in, key []byte, outlen int) {
+    var state Blake2s
+    var x_key [WC_BLAKE2S_256_BLOCK_SIZE]byte
+    var i_hash [WC_BLAKE2S_256_DIGEST_SIZE]byte
+
+    i := 0
+
+    inlen := len(in)
+    keylen := len(key)
+
+    if outlen != WC_BLAKE2S_256_DIGEST_SIZE {
+       return
+   }
+
+    if keylen > WC_BLAKE2S_256_BLOCK_SIZE {
+        Wc_InitBlake2s(&state, WC_BLAKE2S_256_DIGEST_SIZE)
+        Wc_Blake2sUpdate(&state, key, keylen)
+        Wc_Blake2sFinal(&state, x_key[:], 0)
+    } else {
+        copy(x_key[:], key)
+        for i = keylen; i < WC_BLAKE2S_256_BLOCK_SIZE; i++ {
+            x_key[i] = 0
+        }
+    }
+
+    for i = 0; i < WC_BLAKE2S_256_BLOCK_SIZE; i++ {
+        x_key[i] ^= 0x36
+    }
+
+    Wc_InitBlake2s(&state, WC_BLAKE2S_256_DIGEST_SIZE)
+    Wc_Blake2sUpdate(&state, x_key[:], WC_BLAKE2S_256_BLOCK_SIZE)
+    Wc_Blake2sUpdate(&state, in, inlen)
+    Wc_Blake2sFinal(&state, i_hash[:], 0)
+
+    for i = 0; i < WC_BLAKE2S_256_BLOCK_SIZE; i++ {
+        x_key[i] ^= 0x5c ^ 0x36
+    }
+
+    Wc_InitBlake2s(&state, WC_BLAKE2S_256_DIGEST_SIZE)
+    Wc_Blake2sUpdate(&state, x_key[:], WC_BLAKE2S_256_BLOCK_SIZE)
+    Wc_Blake2sUpdate(&state, i_hash[:], WC_BLAKE2S_256_DIGEST_SIZE)
+    Wc_Blake2sFinal(&state, i_hash[:], 0)
+
+    copy(out[:], i_hash[:])
+    zeroMemory(i_hash[:])
+    zeroMemory(x_key[:])
+}

--- a/chacha_poly.go
+++ b/chacha_poly.go
@@ -46,6 +46,7 @@ package wolfSSL
 //                byte* outPlaintext) {
 //      return -174;
 // }
+// #endif
 // #ifndef HAVE_XCHACHA
 // int wc_XChaCha20Poly1305_Encrypt(
 //    byte *dst, size_t dst_space,
@@ -63,7 +64,6 @@ package wolfSSL
 //    const byte *key, size_t key_len) {
 //      return -174;
 // }
-// #endif
 // #endif
 import "C"
 import (

--- a/chacha_poly.go
+++ b/chacha_poly.go
@@ -1,0 +1,182 @@
+/* chacha_poly.go
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package wolfSSL
+
+// #include <wolfssl/options.h>
+// #include <wolfssl/wolfcrypt/chacha20_poly1305.h>
+// #ifndef HAVE_CHACHA
+// #define CHACHA20_POLY1305_AEAD_KEYSIZE 1
+// #define CHACHA20_POLY1305_AEAD_IV_SIZE 1
+// #define CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE 1
+// #define XCHACHA20_POLY1305_AEAD_NONCE_SIZE  1
+// int wc_ChaCha20Poly1305_Encrypt(
+//                 byte inKey[CHACHA20_POLY1305_AEAD_KEYSIZE],
+//                 byte inIV[CHACHA20_POLY1305_AEAD_IV_SIZE],
+//                 byte* inAAD, word32 inAADLen,
+//                 byte* inPlaintext, word32 inPlaintextLen,
+//                byte* outCiphertext,
+//                byte outAuthTag[CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE]) {
+//      return -174;
+// }
+// int wc_ChaCha20Poly1305_Decrypt(
+//                 byte inKey[CHACHA20_POLY1305_AEAD_KEYSIZE],
+//                 byte inIV[CHACHA20_POLY1305_AEAD_IV_SIZE],
+//                 byte* inAAD, word32 inAADLen,
+//                 byte* inCiphertext, word32 inCiphertextLen,
+//                 byte inAuthTag[CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE],
+//                byte* outPlaintext) {
+//      return -174;
+// }
+// #ifndef HAVE_XCHACHA
+// int wc_XChaCha20Poly1305_Encrypt(
+//    byte *dst, size_t dst_space,
+//    const byte *src, size_t src_len,
+//    const byte *ad, size_t ad_len,
+//    const byte *nonce, size_t nonce_len,
+//    const byte *key, size_t key_len) {
+//      return -174;
+// }
+// int wc_XChaCha20Poly1305_Decrypt(
+//    byte *dst, size_t dst_space,
+//    const byte *src, size_t src_len,
+//    const byte *ad, size_t ad_len,
+//    const byte *nonce, size_t nonce_len,
+//    const byte *key, size_t key_len) {
+//      return -174;
+// }
+// #endif
+// #endif
+import "C"
+import (
+    "unsafe"
+)
+
+const CHACHA20_POLY1305_AEAD_KEYSIZE = int(C.CHACHA20_POLY1305_AEAD_KEYSIZE)
+const CHACHA20_POLY1305_AEAD_IV_SIZE = int(C.CHACHA20_POLY1305_AEAD_IV_SIZE)
+const CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE = int(C.CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE)
+const XCHACHA20_POLY1305_AEAD_NONCE_SIZE = int(C.XCHACHA20_POLY1305_AEAD_NONCE_SIZE)
+const CHACHA20_POLY1305_AEAD_NONCE_SIZE = XCHACHA20_POLY1305_AEAD_NONCE_SIZE/2
+
+func Wc_ChaCha20Poly1305_Encrypt(inKey, inIv, inAAD, inPlain, outCipher, outAuthTag []byte) int {
+    var sanInAAD *C.uchar
+    if len(inAAD) > 0 {
+        sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
+    } else {
+        sanInAAD = (*C.uchar)(unsafe.Pointer(nil))
+    }
+    var sanInPlain *C.uchar
+    if len(inPlain) > 0 {
+        sanInPlain = (*C.uchar)(unsafe.Pointer(&inPlain[0]))
+    } else {
+        sanInPlain = (*C.uchar)(unsafe.Pointer(nil))
+    }
+    var sanOutCipher *C.uchar
+    if len(outCipher) > 0 {
+        sanOutCipher = (*C.uchar)(unsafe.Pointer(&outCipher[0]))
+    } else {
+        outCipher = make([]byte, CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE)
+        sanOutCipher = (*C.uchar)(unsafe.Pointer(&outCipher[0]))
+    }
+    return int(C.wc_ChaCha20Poly1305_Encrypt((*C.uchar)(unsafe.Pointer(&inKey[0])), (*C.uchar)(unsafe.Pointer(&inIv[0])),
+               sanInAAD, C.word32(len(inAAD)), sanInPlain, C.word32(len(inPlain)),
+               sanOutCipher, (*C.uchar)(unsafe.Pointer(&outAuthTag[0]))))
+}
+
+func Wc_ChaCha20Poly1305_Decrypt(inKey, inIv, inAAD, inCipher, inAuthTag , outPlain []byte) int {
+    var sanInAAD *C.uchar
+    if len(inAAD) > 0 {
+        sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
+    } else {
+        sanInAAD = (*C.uchar)(unsafe.Pointer(nil))
+    }
+    var sanInCipher *C.uchar
+    if len(inCipher) > 0 {
+        sanInCipher = (*C.uchar)(unsafe.Pointer(&inCipher[0]))
+    } else {
+        inCipher = make([]byte, CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE)
+        sanInCipher = (*C.uchar)(unsafe.Pointer(&inCipher[0]))
+    }
+
+    return int(C.wc_ChaCha20Poly1305_Decrypt((*C.uchar)(unsafe.Pointer(&inKey[0])), (*C.uchar)(unsafe.Pointer(&inIv[0])),
+               sanInAAD, C.word32(len(inAAD)), sanInCipher, C.word32(len(inCipher)),
+               (*C.uchar)(unsafe.Pointer(&inAuthTag[0])), (*C.uchar)(unsafe.Pointer(&outPlain[0]))))
+}
+
+func Wc_ChaCha20Poly1305_Appended_Tag_Encrypt(inKey, inIv, inAAD, inPlain, outCipher []byte) ([]byte, int) {
+    var outAuthTag [CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE]byte
+    var longOutCipher []byte
+
+    if len(outCipher) < (len(inPlain) + CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE) {
+        longOutCipher = make([]byte, len(inPlain) + CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE)
+    } else {
+        longOutCipher = outCipher
+    }
+
+    ret := Wc_ChaCha20Poly1305_Encrypt(inKey, inIv, inAAD, inPlain, longOutCipher[:(len(longOutCipher)-CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE)], outAuthTag[:])
+    copy(longOutCipher[(len(longOutCipher)-CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE):], outAuthTag[:])
+    return longOutCipher, ret
+}
+
+func Wc_ChaCha20Poly1305_Appended_Tag_Decrypt(inKey, inIv, inAAD, inCipher,  outPlain []byte) int {
+    var inAuthTag [CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE]byte
+    copy(inAuthTag[:], inCipher[(len(inCipher)-CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE):])
+    ret := Wc_ChaCha20Poly1305_Decrypt(inKey, inIv, inAAD, inCipher[:(len(inCipher)-CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE)], inAuthTag[:] , outPlain)
+    return ret
+}
+
+func Wc_XChaCha20Poly1305_Encrypt(outCipher, inPlain, inAAD, inIv, inKey []byte) int {
+    var sanInAAD *C.uchar
+    if len(inAAD) > 0 {
+        sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
+    } else {
+        sanInAAD = (*C.uchar)(unsafe.Pointer(nil))
+    }
+    var sanInPlain *C.uchar
+    if len(inPlain) > 0 {
+        sanInPlain = (*C.uchar)(unsafe.Pointer(&inPlain[0]))
+    } else {
+        sanInPlain = (*C.uchar)(unsafe.Pointer(nil))
+    }
+    return int(C.wc_XChaCha20Poly1305_Encrypt((*C.uchar)(unsafe.Pointer(&outCipher[0])), C.size_t(len(outCipher)),
+                sanInPlain, C.size_t(len(inPlain)), sanInAAD, C.size_t(len(inAAD)),
+                (*C.uchar)(unsafe.Pointer(&inIv[0])), C.size_t(len(inIv)),
+                (*C.uchar)(unsafe.Pointer(&inKey[0])), C.size_t(len(inKey))))
+}
+
+func Wc_XChaCha20Poly1305_Decrypt(outPlain, inCipher, inAAD, inIv, inKey []byte) int {
+    var sanInAAD *C.uchar
+    if len(inAAD) > 0 {
+        sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
+    } else {
+        sanInAAD = (*C.uchar)(unsafe.Pointer(nil))
+    }
+    var sanInCipher *C.uchar
+    if len(inCipher) > 0 {
+        sanInCipher = (*C.uchar)(unsafe.Pointer(&inCipher[0]))
+    } else {
+        sanInCipher = (*C.uchar)(unsafe.Pointer(nil))
+    }
+    return int(C.wc_XChaCha20Poly1305_Decrypt((*C.uchar)(unsafe.Pointer(&outPlain[0])), C.size_t(len(outPlain)),
+                sanInCipher, C.size_t(len(inCipher)), sanInAAD, C.size_t(len(inAAD)),
+                (*C.uchar)(unsafe.Pointer(&inIv[0])), C.size_t(len(inIv)),
+                (*C.uchar)(unsafe.Pointer(&inKey[0])), C.size_t(len(inKey))))
+}

--- a/curve25519.go
+++ b/curve25519.go
@@ -1,0 +1,116 @@
+/* curve25519.go
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package wolfSSL
+
+// #include <wolfssl/options.h>
+// #include <wolfssl/wolfcrypt/curve25519.h>
+// #include <wolfssl/wolfcrypt/random.h>
+// #ifndef HAVE_CURVE25519
+// typedef struct curve25519_key {} curve25519_key;
+// #define EC25519_LITTLE_ENDIAN 1
+// int wc_curve25519_init(curve25519_key* key) {
+//     return -174;
+// }
+// void wc_curve25519_free(curve25519_key* key)  {
+//     return;
+// }
+// int wc_curve25519_import_private(const byte* priv, word32 privSz, curve25519_key* key) {
+//     return -174;
+// }
+// int wc_curve25519_import_public(const byte* in, word32 inLen, curve25519_key* key) {
+//     return -174;
+// }
+// int wc_curve25519_export_private_raw(curve25519_key* key, byte* out, word32* outLen) {
+//     return -174;
+// }
+// int wc_curve25519_make_key(WC_RNG* rng, int keysize, curve25519_key* key) {
+//     return -174;
+// }
+// int wc_curve25519_make_priv(WC_RNG* rng, int keysize, byte* priv) {
+//     return -174;
+// }
+// int wc_curve25519_make_pub(int public_size, byte* pub, int private_size, byte* priv) {
+//     return -174;
+// }
+// int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
+//                                   curve25519_key* public_key,
+//                                   byte* out, word32* outlen, int endian) {
+//     return -174;
+// }
+// int wc_curve25519_import_private_ex(const byte* priv, word32 privSz,
+//                                     curve25519_key* key, int endian) {
+//      return -174;
+// }
+// int wc_curve25519_import_public_ex(const byte* in, word32 inLen,
+//                                    curve25519_key* key, int endian) {
+//      return -174;
+// }
+// #endif
+import "C"
+import (
+    "unsafe"
+)
+
+type Curve25519_key = C.struct_curve25519_key
+
+func Wc_curve25519_init(key *C.struct_curve25519_key) int {
+    return int(C.wc_curve25519_init(key))
+}
+
+func Wc_curve25519_free(key *C.struct_curve25519_key) {
+    C.wc_curve25519_free(key)
+}
+
+func Wc_curve25519_make_key(rng *C.struct_WC_RNG, keySize int, key *C.struct_curve25519_key) int {
+    return int(C.wc_curve25519_make_key(rng, C.int(keySize), key))
+}
+
+func Wc_curve25519_make_pub(pub, priv []byte) int {
+    return int(C.wc_curve25519_make_pub(C.int(len(pub)),(*C.uchar)(unsafe.Pointer(&pub[0])),
+               C.int(len(priv)), (*C.uchar)(unsafe.Pointer(&priv[0]))))
+}
+
+func Wc_curve25519_make_priv(rng *C.struct_WC_RNG, priv []byte) int {
+    return int(C.wc_curve25519_make_priv(rng,
+               C.int(len(priv)), (*C.uchar)(unsafe.Pointer(&priv[0]))))
+}
+
+func Wc_curve25519_import_private(priv []byte, key *C.struct_curve25519_key) int {
+    return int(C.wc_curve25519_import_private_ex((*C.uchar)(unsafe.Pointer(&priv[0])),
+               C.word32(len(priv)), key, C.EC25519_LITTLE_ENDIAN))
+}
+
+func Wc_curve25519_import_public(pub []byte, key *C.struct_curve25519_key) int {
+    return int(C.wc_curve25519_import_public_ex((*C.uchar)(unsafe.Pointer(&pub[0])),
+               C.word32(len(pub)), key, C.EC25519_LITTLE_ENDIAN))
+}
+
+func Wc_curve25519_export_private_raw(key *C.struct_curve25519_key, priv []byte) int {
+    outLen := len(priv)
+    return int(C.wc_curve25519_export_private_raw(key, (*C.uchar)(unsafe.Pointer(&priv[0])), (*C.word32)(unsafe.Pointer(&outLen))))
+}
+
+func Wc_curve25519_shared_secret(privKey, pubKey *C.struct_curve25519_key, out []byte) int {
+    outLen := len(out)
+    return int(C.wc_curve25519_shared_secret_ex(privKey, pubKey, (*C.uchar)(unsafe.Pointer(&out[0])),
+               (*C.word32)(unsafe.Pointer(&outLen)), C.EC25519_LITTLE_ENDIAN))
+}

--- a/ecc.go
+++ b/ecc.go
@@ -21,10 +21,9 @@
 
 package wolfSSL
 
-// #cgo CFLAGS: -g -Wall -I/usr/include -I/usr/include/wolfssl
-// #cgo LDFLAGS: -L/usr/local/lib -lwolfssl -lm
 // #include <wolfssl/options.h>
 // #include <wolfssl/wolfcrypt/ecc.h>
+// #include <wolfssl/wolfcrypt/curve25519.h>
 // #include <wolfssl/wolfcrypt/random.h>
 // #ifndef HAVE_ECC
 // #define ECC_MAX_SIG_SIZE 1
@@ -77,3 +76,4 @@ func Wc_ecc_verify_hash(sig []byte, sigLen int, hash []byte, hashLen int, res *i
     return int(C.wc_ecc_verify_hash((*C.uchar)(unsafe.Pointer(&sig[0])), C.word32(sigLen),
                (*C.uchar)(unsafe.Pointer(&hash[0])), C.word32(sigLen), (*C.int)(unsafe.Pointer(res)), key))
 }
+

--- a/hash.go
+++ b/hash.go
@@ -21,8 +21,6 @@
 
 package wolfSSL
 
-// #cgo CFLAGS: -g -Wall -I/usr/include -I/usr/include/wolfssl
-// #cgo LDFLAGS: -L/usr/local/lib -lwolfssl -lm
 // #include <wolfssl/options.h>
 // #include <wolfssl/wolfcrypt/hash.h>
 // #ifdef NO_MD5

--- a/hmac.go
+++ b/hmac.go
@@ -1,6 +1,6 @@
-/* random.go
+/* hmac.go
  *
- * Copyright (C) 2006-2022 wolfSSL Inc.
+ * Copyright (C) 2006-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -22,35 +22,28 @@
 package wolfSSL
 
 // #include <wolfssl/options.h>
-// #include <wolfssl/wolfcrypt/random.h>
-// #ifdef WC_NO_RNG
-// typedef struct WC_RNG {} WC_RNG;
-// int wc_InitRng(WC_RNG* rng) {
-//      return -174;
-// }
-// int wc_FreeRng(WC_RNG* rng) {
-//      return -174;
-// }
-// int wc_RNG_GenerateBlock(WC_RNG* rng, byte* b, word32 sz) {
-//      return -174;
-// }
-// #endif
+// #include <wolfssl/wolfcrypt/hmac.h>
 import "C"
 import (
     "unsafe"
 )
 
-type WC_RNG = C.struct_WC_RNG
+type Hmac = C.struct_Hmac
 
-func Wc_InitRng(rng *C.struct_WC_RNG) int {
-    return int(C.wc_InitRng(rng))
+// PASS IN NILL HERE
+func Wc_HmacInit(hmac *C.struct_Hmac, heap unsafe.Pointer, devId int) int {
+    return int(C.wc_HmacInit(hmac, heap, C.int(devId)))
 }
 
-func Wc_FreeRng(rng *C.struct_WC_RNG) int {
-    return int(C.wc_FreeRng(rng))
+func Wc_HmacSetKey(hmac *C.struct_Hmac, hash int, key []byte, keySz int) int {
+    return int(C.wc_HmacSetKey(hmac, C.int(hash), (*C.uchar)(unsafe.Pointer(&key[0])),
+               C.word32(keySz)))
 }
 
-func Wc_RNG_GenerateBlock(rng *C.struct_WC_RNG, b []byte, sz int) int {
-    return int(C.wc_RNG_GenerateBlock(rng, (*C.uchar)(unsafe.Pointer(&b[0])),
-               C.word32(sz)))
+func Wc_HmacUpdate(hmac *C.struct_Hmac, in []byte, inSz int) int {
+    return int(C.wc_HmacUpdate(hmac, (*C.uchar)(unsafe.Pointer(&in[0])), C.word32(inSz)))
+}
+
+func Wc_HmacFinal(hmac *C.struct_Hmac, out []byte) int {
+    return int(C.wc_HmacFinal(hmac, (*C.uchar)(unsafe.Pointer(&out[0]))))
 }

--- a/hmac.go
+++ b/hmac.go
@@ -30,18 +30,33 @@ import (
 
 type Hmac = C.struct_Hmac
 
-// PASS IN NILL HERE
 func Wc_HmacInit(hmac *C.struct_Hmac, heap unsafe.Pointer, devId int) int {
     return int(C.wc_HmacInit(hmac, heap, C.int(devId)))
 }
 
+func Wc_HmacFree(hmac *C.struct_Hmac) {
+    C.wc_HmacFree(hmac)
+}
+
 func Wc_HmacSetKey(hmac *C.struct_Hmac, hash int, key []byte, keySz int) int {
-    return int(C.wc_HmacSetKey(hmac, C.int(hash), (*C.uchar)(unsafe.Pointer(&key[0])),
-               C.word32(keySz)))
+    var sanKey *C.uchar
+    if len(key) > 0 {
+        sanKey = (*C.uchar)(unsafe.Pointer(&key[0]))
+    } else {
+        sanKey = (*C.uchar)(unsafe.Pointer(nil))
+    }
+    return int(C.wc_HmacSetKey(hmac, C.int(hash), sanKey, C.word32(keySz)))
 }
 
 func Wc_HmacUpdate(hmac *C.struct_Hmac, in []byte, inSz int) int {
-    return int(C.wc_HmacUpdate(hmac, (*C.uchar)(unsafe.Pointer(&in[0])), C.word32(inSz)))
+    var sanIn *C.uchar
+    if len(in) > 0 {
+        sanIn = (*C.uchar)(unsafe.Pointer(&in[0]))
+    } else {
+        sanIn = (*C.uchar)(unsafe.Pointer(nil))
+    }
+
+    return int(C.wc_HmacUpdate(hmac, sanIn, C.word32(inSz)))
 }
 
 func Wc_HmacFinal(hmac *C.struct_Hmac, out []byte) int {

--- a/misc.go
+++ b/misc.go
@@ -1,0 +1,42 @@
+/* misc.go
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package wolfSSL
+
+func ConstantCompare(a, b []byte, length int) int {
+
+	var result byte = 0
+	for i := 0; i < length; i++ {
+		result |= a[i] ^ b[i]
+	}
+
+        if result == 0 {
+		return 1
+	} else {
+		return 0
+	}
+}
+
+func zeroMemory(b []byte) {
+    for i := range b {
+        b[i] = 0
+    }
+}

--- a/misc.go
+++ b/misc.go
@@ -22,17 +22,16 @@
 package wolfSSL
 
 func ConstantCompare(a, b []byte, length int) int {
+    var result byte = 0
+    for i := 0; i < length; i++ {
+            result |= a[i] ^ b[i]
+    }
 
-	var result byte = 0
-	for i := 0; i < length; i++ {
-		result |= a[i] ^ b[i]
-	}
-
-        if result == 0 {
-		return 1
-	} else {
-		return 0
-	}
+    if result == 0 {
+            return 1
+    } else {
+            return 0
+    }
 }
 
 func zeroMemory(b []byte) {

--- a/misc.go
+++ b/misc.go
@@ -24,13 +24,13 @@ package wolfSSL
 func ConstantCompare(a, b []byte, length int) int {
     var result byte = 0
     for i := 0; i < length; i++ {
-            result |= a[i] ^ b[i]
+        result |= a[i] ^ b[i]
     }
 
     if result == 0 {
-            return 1
+        return 1
     } else {
-            return 0
+        return 0
     }
 }
 

--- a/ssl.go
+++ b/ssl.go
@@ -21,8 +21,6 @@
 
 package wolfSSL
 
-// #cgo CFLAGS: -g -Wall -I/usr/include -I/usr/include/wolfssl
-// #cgo LDFLAGS: -L/usr/local/lib -lwolfssl -lm
 // #include <wolfssl/options.h>
 // #include <wolfssl/ssl.h>
 // #ifdef NO_PSK


### PR DESCRIPTION
Includes a small refactor and support for the following algos:

- Blake2s
- Chacha20_Poly1305
- Curve25519
- HMAC

