### PR TITLE
Functionality required for FIPS Wireguard Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,34 +14,24 @@ make
 sudo make install
 ``` 
 
-Then run the command below to build and install the wrapper module.
+Then clone the go-wolfssl repo and run the `./generateOptions.sh` script to customize go-wolfssl to the same feature set as wolfSSL. This script will generate an `options.go` file that will keep go-wolfssl and wolfSSL in sync. `generateOptions` should be run any time you change your wolfSSL configure options. If the path to your wolfSSL directory is `../wolfssl`, just run: 
 ```
-go get -u github.com/wolfssl/go-wolfssl 
-```
-
-## Building with configure options
-
-If building wolfSSL with a non-empty configure, you'll have to run the `./generateOptions.sh` executable to customize go-wolfssl to the same feature set as wolfSSL. This executable will generate an `options.go` file that will keep go-wolfssl and wolfSSL in sync. `generateOptions` should be run any time you change your wolfSSL configure options. 
-
-Example: To use go-wolfssl without ECC, first build wolfSSL as shown below:
-```
-./configure --disable-ecc
-make
-sudo make install
+git clone https://github.com/wolfSSL/go-wolfssl
+cd go-wolfssl
+./generateOptions.sh
 ``` 
 
-Then go to the go-wolfssl directory and if the path to your wolfSSL directory is `../wolfssl`, just run:
-```
-./generateOptions.sh
-```
-
-If you have a different path to your wolfSSL directory, run the executable with the right path:
+If you have a different path to your wolfSSL directory, run the script with the right path:
 ```
 ./generateOptions ../files/wolfSSL
 ``` 
 
-options.go is now generated and go-wolfssl can be run with ECC disabled!
- 
+To install the wrapper module, run these commands:
+```
+go get -u github.com/wolfssl/go-wolfssl 
+go mod edit -replace github.com/wolfssl/go-wolfssl=<path to your go-wolfssl directory>
+```
+
 ## Running the TLS Server/Client example
 
 The example `.go` files are located in the `client` and `server` directories. 

--- a/chacha_poly.go
+++ b/chacha_poly.go
@@ -93,8 +93,8 @@ func Wc_ChaCha20Poly1305_Encrypt(inKey, inIv, inAAD, inPlain, outCipher, outAuth
     if len(outCipher) > 0 {
         sanOutCipher = (*C.uchar)(unsafe.Pointer(&outCipher[0]))
     } else {
-        outCipher = make([]byte, CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE)
-        sanOutCipher = (*C.uchar)(unsafe.Pointer(&outCipher[0]))
+        emptyStringArray := []byte("")
+        sanOutCipher = (*C.uchar)(unsafe.Pointer(&emptyStringArray))
     }
     return int(C.wc_ChaCha20Poly1305_Encrypt((*C.uchar)(unsafe.Pointer(&inKey[0])), (*C.uchar)(unsafe.Pointer(&inIv[0])),
                sanInAAD, C.word32(len(inAAD)), sanInPlain, C.word32(len(inPlain)),
@@ -112,8 +112,8 @@ func Wc_ChaCha20Poly1305_Decrypt(inKey, inIv, inAAD, inCipher, inAuthTag , outPl
     if len(inCipher) > 0 {
         sanInCipher = (*C.uchar)(unsafe.Pointer(&inCipher[0]))
     } else {
-        inCipher = make([]byte, CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE)
-        sanInCipher = (*C.uchar)(unsafe.Pointer(&inCipher[0]))
+        emptyStringArray := []byte("")
+        sanInCipher = (*C.uchar)(unsafe.Pointer(&emptyStringArray))
     }
 
     return int(C.wc_ChaCha20Poly1305_Decrypt((*C.uchar)(unsafe.Pointer(&inKey[0])), (*C.uchar)(unsafe.Pointer(&inIv[0])),

--- a/fips.go
+++ b/fips.go
@@ -1,0 +1,69 @@
+/* fips.go
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package wolfSSL
+
+// #include <wolfssl/options.h>
+// #include <wolfssl/wolfcrypt/types.h>
+// #include <wolfssl/wolfcrypt/random.h>
+// #include <wolfssl/wolfcrypt/fips_test.h>
+// #ifndef WC_RNG_SEED_CB
+// typedef int (*wc_RngSeed_Cb)(OS_Seed* os, byte* seed, word32 sz);
+// int wc_SetSeed_Cb(wc_RngSeed_Cb cb) {
+//      return -174;
+//  }
+// #endif
+// #define WC_SPKRE_F(x,y) wolfCrypt_SetPrivateKeyReadEnable_fips((x),(y))
+// #ifdef HAVE_FIPS
+// int WC_PRIVATE_KEY_LOCK(void) {
+//      return WC_SPKRE_F(0,WC_KEYTYPE_ALL);
+// }
+// int WC_PRIVATE_KEY_UNLOCK(void) {
+//      return WC_SPKRE_F(1,WC_KEYTYPE_ALL);
+// }
+// #else
+// int WC_PRIVATE_KEY_LOCK(void) {
+//      return -174;
+// }
+// int WC_PRIVATE_KEY_UNLOCK(void) {
+//      return -174;
+// }
+// int wc_RunAllCast_fips(void) {
+//      return -174;
+// }
+// #endif
+import "C"
+
+func Wc_SetDefaultSeed_Cb() int {
+    return int(C.wc_SetSeed_Cb((C.wc_RngSeed_Cb)(C.wc_GenerateSeed)))
+}
+
+func PRIVATE_KEY_LOCK() int {
+    return int(C.WC_PRIVATE_KEY_LOCK())
+}
+
+func PRIVATE_KEY_UNLOCK() int {
+    return int(C.WC_PRIVATE_KEY_UNLOCK())
+}
+
+func Wc_RunAllCast_fips() int {
+    return int(C.wc_RunAllCast_fips())
+}

--- a/sha.go
+++ b/sha.go
@@ -1,0 +1,54 @@
+/* sha.go
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package wolfSSL
+
+// #include <wolfssl/options.h>
+// #include <wolfssl/wolfcrypt/sha256.h>
+import "C"
+import (
+    "unsafe"
+)
+
+type Wc_Sha256 = C.struct_wc_Sha256
+
+func Wc_InitSha256_ex(sha *C.struct_wc_Sha256, heap unsafe.Pointer, devId int) int {
+    return int(C.wc_InitSha256_ex(sha, heap, C.int(devId)))
+}
+
+func Wc_Sha256Free(sha *C.struct_wc_Sha256) {
+    C.wc_Sha256Free(sha)
+}
+
+func Wc_Sha256Update(sha *C.struct_wc_Sha256, in []byte, inSz int) int {
+    var sanIn *C.uchar
+    if len(in) > 0 {
+        sanIn = (*C.uchar)(unsafe.Pointer(&in[0]))
+    } else {
+        sanIn = (*C.uchar)(unsafe.Pointer(nil))
+    }
+
+    return int(C.wc_Sha256Update(sha, sanIn, C.word32(inSz)))
+}
+
+func Wc_Sha256Final(sha *C.struct_wc_Sha256, out []byte) int {
+    return int(C.wc_Sha256Final(sha, (*C.uchar)(unsafe.Pointer(&out[0]))))
+}


### PR DESCRIPTION
Includes API additions for:
- ECC
- AES GCM
- SHA256
- FIPS