### PR TITLE
Remove ecc_point type from ecc.go

### DIFF
--- a/ecc.go
+++ b/ecc.go
@@ -54,7 +54,6 @@ import (
 const ECC_MAX_SIG_SIZE = int(C.ECC_MAX_SIG_SIZE)
 
 type Ecc_key = C.struct_ecc_key
-type Ecc_point = C.struct_ecc_point
 
 const ECC_SECP256R1 = int(C.ECC_SECP256R1)
 
@@ -70,8 +69,8 @@ func Wc_ecc_make_key(rng *C.struct_WC_RNG, keySize int, key *C.struct_ecc_key) i
     return int(C.wc_ecc_make_key(rng, C.int(keySize), key))
 }
 
-func Wc_ecc_make_pub(key *C.struct_ecc_key, point *C.struct_ecc_point) int {
-    return int(C.wc_ecc_make_pub(key, point))
+func Wc_ecc_make_pub_in_priv(key *C.struct_ecc_key) int {
+    return int(C.wc_ecc_make_pub(key, nil))
 }
 
 func Wc_ecc_set_rng(key *C.struct_ecc_key, rng *C.struct_WC_RNG) int {


### PR DESCRIPTION
The ecc_point struct was causing the build error below when working with the wolfSSL FIPS 140-3 bundle. Removing the struct from the wrapper because it is not yet necessary.
```
cannot use point (variable of type *_Ctype_struct_ecc_point) as *_Ctype_struct___0 value in variable declaration
```

If this ever becomes requirement to add in the future, the ecc.h header in the FIPS bundle needs the following patch to get things building.

```
diff --git a/wolfssl/wolfcrypt/ecc.h b/wolfssl/wolfcrypt/ecc.h
index fa97b11fc..de6ae29e1 100644
--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -381,10 +381,14 @@ typedef struct alt_fp_int {
     #define WC_ECCKEY_TYPE_DEFINED
 #endif
 
+#ifndef WC_ECCPOINT_TYPE_DEFINED
+    typedef struct ecc_point ecc_point;
+    #define WC_ECCPOINT_TYPE_DEFINED
+#endif
 
 /* A point on an ECC curve, stored in Jacobian format such that (x,y,z) =>
    (x/z^2, y/z^3, 1) when interpreted as affine */
-typedef struct {
+struct ecc_point {
 #ifndef ALT_ECC_SIZE
     mp_int x[1];        /* The x coordinate */
     mp_int y[1];        /* The y coordinate */
@@ -395,10 +399,10 @@ typedef struct {
     mp_int* z;        /* The z coordinate */
     alt_fp_int xyz[3];
 #endif
-#ifdef WOLFSSL_SMALL_STACK_CACHE
+#if defined(WOLFSSL_SMALL_STACK_CACHE)
     ecc_key* key;
 #endif
-} ecc_point;
+};
 
 /* ECC Flags */
 enum {
```