### PR TITLE
Adding X509 functionality and examples

### DIFF
--- a/aes.go
+++ b/aes.go
@@ -1,6 +1,6 @@
 /* aes.go
  *
- * Copyright (C) 2006-2022 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/blake2.go
+++ b/blake2.go
@@ -1,6 +1,6 @@
 /* blake2s.go
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/chacha_poly.go
+++ b/chacha_poly.go
@@ -1,6 +1,6 @@
 /* chacha_poly.go
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/curve25519.go
+++ b/curve25519.go
@@ -1,6 +1,6 @@
 /* curve25519.go
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/ecc.go
+++ b/ecc.go
@@ -1,6 +1,6 @@
 /* ecc.go
  *
- * Copyright (C) 2006-2022 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/ecc.go
+++ b/ecc.go
@@ -45,6 +45,10 @@ package wolfSSL
 //                        word32 hashlen, int* res, ecc_key* key) {
 //      return -174;
 //  }
+// int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
+//                        ecc_key* key, word32 inSz) {
+//      return -174;
+//  }
 // #endif
 import "C"
 import (
@@ -121,4 +125,8 @@ func Wc_ecc_shared_secret(privKey, pubKey *C.struct_ecc_key, out []byte, outLen 
     ret := int(C.wc_ecc_shared_secret(privKey, pubKey, (*C.uchar)(unsafe.Pointer(&out[0])), &cOutLen))
     *outLen = int(cOutLen)
     return ret
+}
+
+func Wc_EccPublicKeyDecode(pubKey []byte, idx *int, key *C.struct_ecc_key, pubSz int) int {
+	return int(C.wc_EccPublicKeyDecode((*C.uchar)(unsafe.Pointer(&pubKey[0])), (*C.word32)(unsafe.Pointer(idx)), key, C.word32(pubSz)))
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,3 +80,21 @@ To build the app, run :
 go build ecc-sign-verify.go
 ```
 
+## Building the x509 cert verify example
+
+An application that loads a root CA, two intermediate certs, then verifies the leaf cert. Make sure wolfSSL was configured with "--enable-opensslall" to run this example. Located in `x509` directory.
+
+To build the app, run :
+```
+go build certVerify.go
+```
+
+## Building the x509 extract key example
+
+An application that loads an X509 cert, extracts the public key DER buffer from it, and demonstrates how to import der buffer into an ecc key object. Make sure wolfSSL was configured with "--enable-opensslall" to run this example. Located in `x509` directory.
+
+To build the app, run :
+```
+go build extractKey.go
+```
+

--- a/examples/certs/ca-cert.pem
+++ b/examples/certs/ca-cert.pem
@@ -2,16 +2,16 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            26:8c:93:f9:f9:f4:1e:b3:01:72:94:55:67:6d:e2:f8:3d:da:e9:f4
+            6b:9b:70:c6:f1:a3:94:65:19:a1:08:58:ef:a7:8d:2b:7a:83:c1:da
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Validity
-            Not Before: Feb 15 12:50:24 2022 GMT
-            Not After : Nov 11 12:50:24 2024 GMT
+            Not Before: Dec 18 21:25:29 2024 GMT
+            Not After : Sep 14 21:25:29 2027 GMT
         Subject: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
                     00:bf:0c:ca:2d:14:b2:1e:84:42:5b:cd:38:1f:4a:
                     f2:4d:75:10:f1:b6:35:9f:df:ca:7d:03:98:d3:ac:
@@ -38,8 +38,7 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:26:8C:93:F9:F9:F4:1E:B3:01:72:94:55:67:6D:E2:F8:3D:DA:E9:F4
-
+                serial:6B:9B:70:C6:F1:A3:94:65:19:A1:08:58:EF:A7:8D:2B:7A:83:C1:DA
             X509v3 Basic Constraints: 
                 CA:TRUE
             X509v3 Subject Alternative Name: 
@@ -47,27 +46,28 @@ Certificate:
             X509v3 Extended Key Usage: 
                 TLS Web Server Authentication, TLS Web Client Authentication
     Signature Algorithm: sha256WithRSAEncryption
-         62:e4:1b:28:3c:9d:d2:60:a9:55:be:6a:f6:20:f2:da:e8:a1:
-         1a:97:b1:90:77:82:ed:c7:77:29:53:33:18:10:62:e0:bd:93:
-         1b:d2:d6:a1:80:43:1d:64:f1:42:92:ec:b7:b8:f0:6b:da:59:
-         83:f4:b8:87:e6:fc:70:21:ea:62:32:70:68:14:0e:dc:b4:f1:
-         66:e2:6e:ab:d2:72:6f:da:df:71:f6:3d:27:97:7d:be:e1:d1:
-         ac:16:ad:d7:4f:aa:9d:0c:1e:6e:a9:5e:7d:57:5b:3c:c7:6d:
-         d2:f2:5c:c3:dc:3d:36:99:8e:ab:c0:7f:13:a5:f4:67:8b:e2:
-         a6:51:31:f1:03:91:00:a8:c4:c5:1d:7f:35:62:b8:1d:a0:a5:
-         ab:ec:32:68:ee:f3:ca:48:16:9f:f4:1e:7e:ea:fa:b0:86:15:
-         52:36:6c:4b:58:44:a7:eb:20:78:6e:7e:e8:00:40:ac:98:d8:
-         53:f3:13:4b:b8:98:66:50:63:ed:af:e5:a4:f6:c9:90:1c:84:
-         0a:09:45:2f:a1:e1:37:63:b5:43:8c:a0:2e:7f:c4:d4:e1:ae:
-         b7:b9:45:13:f8:70:d5:79:06:4f:82:83:4b:98:d7:56:47:64:
-         9a:6a:6d:8e:7a:9d:ef:83:0f:6b:75:0e:47:22:92:f3:b4:b2:
-         84:61:1f:1c
+    Signature Value:
+        77:3b:3d:66:74:bc:97:fe:40:16:e6:ba:a5:d5:d1:84:08:89:
+        69:4f:88:0d:57:a9:ef:8c:c3:97:52:c8:bd:8b:a2:49:3b:b7:
+        f7:5d:1e:d6:14:7f:b2:80:33:da:a0:8a:d3:e1:2f:d5:bc:33:
+        9f:ea:5a:72:24:e5:f8:b8:4b:b3:df:62:90:3b:a8:21:ef:27:
+        42:75:bc:60:02:8e:37:35:99:eb:a3:28:f2:65:4c:ff:7a:f8:
+        8e:cc:23:6d:e5:6a:fe:22:5a:d9:b2:4f:47:c7:e0:ae:98:ef:
+        94:ac:b6:4f:61:81:29:8e:e1:79:2c:46:fc:e9:1a:c3:96:1f:
+        19:93:64:2e:9f:37:72:c5:e4:93:4e:61:5f:38:8e:ae:e8:39:
+        19:e6:97:a8:91:d4:23:7e:1e:d2:d0:53:ec:cc:ac:a0:1d:d0:
+        b7:dd:b1:b7:01:2e:96:cd:85:27:e0:e7:47:e2:c1:c1:00:f6:
+        94:df:77:e7:fa:c6:ef:8a:c0:7c:67:bc:ff:a0:7c:94:3b:7d:
+        86:42:af:3d:83:31:ee:2a:3b:7b:f0:2c:9e:6f:e9:c4:07:81:
+        24:da:05:70:4d:dd:09:ae:9e:72:b8:21:0e:8c:b2:ab:aa:4c:
+        49:10:f7:76:f9:b5:0d:6c:20:d3:df:7a:06:32:8d:29:1f:28:
+        1d:8d:26:33
 -----BEGIN CERTIFICATE-----
-MIIE/zCCA+egAwIBAgIUJoyT+fn0HrMBcpRVZ23i+D3a6fQwDQYJKoZIhvcNAQEL
+MIIE/zCCA+egAwIBAgIUa5twxvGjlGUZoQhY76eNK3qDwdowDQYJKoZIhvcNAQEL
 BQAwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
 b3plbWFuMREwDwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEY
 MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdv
-bGZzc2wuY29tMB4XDTIyMDIxNTEyNTAyNFoXDTI0MTExMTEyNTAyNFowgZQxCzAJ
+bGZzc2wuY29tMB4XDTI0MTIxODIxMjUyOVoXDTI3MDkxNDIxMjUyOVowgZQxCzAJ
 BgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREw
 DwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwP
 d3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29t
@@ -82,12 +82,12 @@ BgNVHSMEgcwwgcmAFCeOZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8G
 A1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3
 dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIU
-JoyT+fn0HrMBcpRVZ23i+D3a6fQwDAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtl
+a5twxvGjlGUZoQhY76eNK3qDwdowDAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtl
 eGFtcGxlLmNvbYcEfwAAATAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
-DQYJKoZIhvcNAQELBQADggEBAGLkGyg8ndJgqVW+avYg8trooRqXsZB3gu3HdylT
-MxgQYuC9kxvS1qGAQx1k8UKS7Le48GvaWYP0uIfm/HAh6mIycGgUDty08WbibqvS
-cm/a33H2PSeXfb7h0awWrddPqp0MHm6pXn1XWzzHbdLyXMPcPTaZjqvAfxOl9GeL
-4qZRMfEDkQCoxMUdfzViuB2gpavsMmju88pIFp/0Hn7q+rCGFVI2bEtYRKfrIHhu
-fugAQKyY2FPzE0u4mGZQY+2v5aT2yZAchAoJRS+h4TdjtUOMoC5/xNThrre5RRP4
-cNV5Bk+Cg0uY11ZHZJpqbY56ne+DD2t1DkcikvO0soRhHxw=
+DQYJKoZIhvcNAQELBQADggEBAHc7PWZ0vJf+QBbmuqXV0YQIiWlPiA1Xqe+Mw5dS
+yL2Lokk7t/ddHtYUf7KAM9qgitPhL9W8M5/qWnIk5fi4S7PfYpA7qCHvJ0J1vGAC
+jjc1meujKPJlTP96+I7MI23lav4iWtmyT0fH4K6Y75Sstk9hgSmO4XksRvzpGsOW
+HxmTZC6fN3LF5JNOYV84jq7oORnml6iR1CN+HtLQU+zMrKAd0LfdsbcBLpbNhSfg
+50fiwcEA9pTfd+f6xu+KwHxnvP+gfJQ7fYZCrz2DMe4qO3vwLJ5v6cQHgSTaBXBN
+3QmunnK4IQ6MsquqTEkQ93b5tQ1sINPfegYyjSkfKB2NJjM=
 -----END CERTIFICATE-----

--- a/examples/certs/ca-int-cert.pem
+++ b/examples/certs/ca-int-cert.pem
@@ -1,0 +1,83 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4096 (0x1000)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+        Validity
+            Not Before: Sep 27 12:10:09 2023 GMT
+            Not After : Sep 22 12:10:09 2043 GMT
+        Subject: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = wolfSSL Intermediate CA, emailAddress = info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c3:a2:73:5d:21:62:20:ce:3a:71:38:a7:94:bb:
+                    db:87:04:1c:5a:1b:9e:4b:0d:3e:ca:f8:a5:f7:0d:
+                    6a:dc:23:90:22:6a:2b:58:63:4a:28:6a:48:a8:e7:
+                    73:1f:a2:55:d8:4d:02:3b:e2:cb:6b:e2:83:c9:51:
+                    8f:77:fd:dc:2d:5d:23:b7:23:9a:7e:b6:29:68:e8:
+                    2a:4e:a9:fe:32:70:31:9e:f0:ef:ee:f8:8d:e3:fc:
+                    f3:d7:28:dd:7a:1d:9e:ad:23:2b:f1:a6:7f:34:52:
+                    29:66:d2:e5:64:55:64:d6:dd:4b:41:3b:55:83:6e:
+                    c0:11:0e:6e:20:c2:16:73:eb:30:ff:09:46:bb:e7:
+                    cc:c6:03:44:41:11:c6:c1:6c:36:2f:4a:f9:91:55:
+                    ca:58:5e:37:b8:28:10:30:89:40:96:77:cf:70:66:
+                    a4:55:fb:69:0b:e7:d9:b2:33:65:db:72:3a:77:b7:
+                    2b:49:fc:b6:cd:58:10:8d:ab:aa:cb:40:45:77:02:
+                    39:18:b3:8f:33:01:48:77:50:be:8e:73:a7:de:36:
+                    a0:49:8e:2c:16:af:b9:fb:42:2d:35:6a:db:34:37:
+                    d5:14:59:7d:65:72:e5:8b:65:55:4b:20:5e:47:f9:
+                    f8:3a:d3:6c:d9:3a:f5:c7:01:46:31:c3:79:9a:18:
+                    be:49
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                EF:69:E0:F7:D5:1D:E6:99:EC:DC:6D:D0:F7:E2:B9:5C:64:71:83:35
+            X509v3 Authority Key Identifier: 
+                27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:1
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        83:d7:44:cb:2d:2e:1e:83:47:9b:e0:24:24:89:90:12:96:a8:
+        f4:c7:ac:ea:8c:dc:ff:93:40:bb:a2:3a:57:60:fd:94:b1:e2:
+        c9:56:be:a5:12:b5:b9:2a:50:57:48:fd:5b:90:96:7b:52:d3:
+        a4:3f:a2:3c:cb:2e:2d:a9:19:17:9a:30:b0:49:cd:78:25:98:
+        1e:f5:3b:37:fa:ec:cb:4d:45:46:b8:45:7f:97:b6:f3:79:e6:
+        2d:31:75:2c:80:f9:db:3b:af:94:31:6b:63:e4:5b:78:7f:6d:
+        52:84:22:60:56:3b:37:0f:8b:7b:5f:5c:f6:f3:f0:1f:d9:00:
+        8b:2a:ca:df:0e:03:94:90:d0:f4:ef:a5:47:8a:b6:7c:db:cf:
+        05:47:70:73:5d:b2:41:44:a0:a0:0e:62:39:7f:cc:06:87:13:
+        35:74:8c:9e:2c:46:2e:e5:0a:d3:92:7a:83:8d:22:8c:06:b3:
+        2f:0d:5c:26:9a:e4:19:cb:61:45:5a:2a:cb:8e:91:e6:63:58:
+        38:c3:14:db:07:8d:1a:9e:dd:f1:07:58:71:de:3d:0b:6c:c1:
+        98:8b:66:33:26:d9:61:db:01:c7:30:b8:e8:0a:bf:7a:58:6b:
+        98:6c:a7:3c:2c:f8:60:b7:05:7b:73:8b:d6:c5:c8:d5:5a:25:
+        03:df:e7:fc
+-----BEGIN CERTIFICATE-----
+MIIEFzCCAv+gAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgZQxCzAJBgNVBAYTAlVT
+MRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhT
+YXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZz
+c2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTIzMDky
+NzEyMTAwOVoXDTQzMDkyMjEyMTAwOVowgZ8xCzAJBgNVBAYTAlVTMRMwEQYDVQQI
+DApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRAwDgYDVQQKDAd3b2xmU1NM
+MRQwEgYDVQQLDAtEZXZlbG9wbWVudDEgMB4GA1UEAwwXd29sZlNTTCBJbnRlcm1l
+ZGlhdGUgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDDonNdIWIgzjpxOKeUu9uHBBxaG55L
+DT7K+KX3DWrcI5AiaitYY0ooakio53MfolXYTQI74str4oPJUY93/dwtXSO3I5p+
+tilo6CpOqf4ycDGe8O/u+I3j/PPXKN16HZ6tIyvxpn80Uilm0uVkVWTW3UtBO1WD
+bsARDm4gwhZz6zD/CUa758zGA0RBEcbBbDYvSvmRVcpYXje4KBAwiUCWd89wZqRV
++2kL59myM2Xbcjp3tytJ/LbNWBCNq6rLQEV3AjkYs48zAUh3UL6Oc6feNqBJjiwW
+r7n7Qi01ats0N9UUWX1lcuWLZVVLIF5H+fg602zZOvXHAUYxw3maGL5JAgMBAAGj
+ZjBkMB0GA1UdDgQWBBTvaeD31R3mmezcbdD34rlcZHGDNTAfBgNVHSMEGDAWgBQn
+jmcRdMMmHT/tM2OzpNgdMOXo1TASBgNVHRMBAf8ECDAGAQH/AgEBMA4GA1UdDwEB
+/wQEAwIBhjANBgkqhkiG9w0BAQsFAAOCAQEAg9dEyy0uHoNHm+AkJImQEpao9Mes
+6ozc/5NAu6I6V2D9lLHiyVa+pRK1uSpQV0j9W5CWe1LTpD+iPMsuLakZF5owsEnN
+eCWYHvU7N/rsy01FRrhFf5e283nmLTF1LID52zuvlDFrY+RbeH9tUoQiYFY7Nw+L
+e19c9vPwH9kAiyrK3w4DlJDQ9O+lR4q2fNvPBUdwc12yQUSgoA5iOX/MBocTNXSM
+nixGLuUK05J6g40ijAazLw1cJprkGcthRVoqy46R5mNYOMMU2weNGp7d8QdYcd49
+C2zBmItmMybZYdsBxzC46Aq/elhrmGynPCz4YLcFe3OL1sXI1VolA9/n/A==
+-----END CERTIFICATE-----

--- a/examples/certs/ca-int2-cert.pem
+++ b/examples/certs/ca-int2-cert.pem
@@ -1,0 +1,84 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4097 (0x1001)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = wolfSSL Intermediate CA, emailAddress = info@wolfssl.com
+        Validity
+            Not Before: Sep 27 12:10:09 2023 GMT
+            Not After : Sep 22 12:10:09 2043 GMT
+        Subject: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = wolfSSL Intermediate2 CA, emailAddress = info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:cf:c9:3d:59:01:9f:1d:77:91:56:cb:ab:06:82:
+                    c1:81:31:9a:e2:f9:c6:f9:a3:40:2d:86:42:d7:5f:
+                    41:a5:05:42:0f:5f:2b:6b:bd:29:92:e5:52:c6:5c:
+                    f9:7e:9d:fb:8e:d6:69:8c:03:91:87:1c:1f:bf:24:
+                    59:44:cc:ef:af:92:2a:06:e1:a1:01:5b:04:57:8a:
+                    1a:b6:04:e2:c2:3c:10:3c:42:31:01:aa:c3:f2:32:
+                    1e:01:95:d0:91:a7:66:c1:22:68:36:53:2a:52:03:
+                    eb:b5:9b:82:01:24:f9:d1:ae:fb:53:4c:5a:06:e5:
+                    6e:5a:d6:ac:5b:28:1a:53:e8:d7:a5:ce:6e:9c:34:
+                    c3:08:0b:cb:2f:8e:df:ef:8c:35:f5:b0:bc:5d:0f:
+                    ae:0a:4a:cf:54:01:d2:3c:b4:78:ee:48:10:56:80:
+                    4f:83:87:4e:67:1f:4f:17:2e:3e:2d:f5:6d:c9:07:
+                    a2:3e:32:92:0f:1e:a4:0b:55:a6:1f:84:ef:9d:75:
+                    ef:66:7c:75:f7:e7:40:3a:9c:c1:33:42:3d:2f:7f:
+                    99:5d:7b:04:d5:a9:6c:41:e8:89:16:58:fd:3a:a0:
+                    04:bd:77:d6:63:5e:6a:13:59:37:5f:f1:59:01:45:
+                    48:9c:8b:f7:16:f4:50:f7:5a:b4:5a:33:f6:f5:41:
+                    c1:3d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                0D:C9:60:20:43:58:81:E0:9A:21:EF:66:16:DC:6E:21:25:DF:2B:45
+            X509v3 Authority Key Identifier: 
+                EF:69:E0:F7:D5:1D:E6:99:EC:DC:6D:D0:F7:E2:B9:5C:64:71:83:35
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:1
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        86:c3:f8:62:d2:10:a0:b4:da:78:e9:85:c5:99:04:24:9e:77:
+        1a:58:a4:9f:26:c7:58:5b:b8:76:80:57:ce:20:a4:e5:de:21:
+        21:3d:70:01:4d:0f:6d:5a:f6:3d:48:68:d2:38:c5:ea:d4:9f:
+        a4:00:b2:e4:de:70:6b:58:b9:a2:a9:9b:dd:a6:a6:8e:6c:c4:
+        f9:5f:d7:17:45:85:be:e8:2f:fb:d2:82:d2:ab:2c:e2:ff:35:
+        20:b4:6c:06:7e:08:51:7a:af:19:73:58:f3:a8:48:65:0a:4f:
+        67:44:7e:c0:fd:4b:94:94:b1:4c:56:85:7a:31:af:09:03:fa:
+        cc:5d:85:55:0b:ac:1b:6a:c9:aa:c4:bb:e4:e0:ad:42:38:f1:
+        6f:74:d7:db:0c:ca:01:e0:f3:4a:c7:eb:f2:6e:30:c6:8e:a3:
+        cf:5a:45:0f:7f:98:92:31:20:fc:26:21:34:15:06:4f:29:a3:
+        5c:15:11:5b:04:94:d5:2c:9b:1e:5b:61:65:dc:6e:6c:00:05:
+        01:ce:2b:48:54:f9:91:2b:4c:8c:bb:db:94:b5:08:53:11:97:
+        15:01:bc:65:28:b6:a2:83:5f:f0:d8:79:84:17:27:75:2a:54:
+        c8:07:31:d7:50:05:51:07:4f:57:c8:bf:49:75:35:a1:39:af:
+        66:ec:26:e1
+-----BEGIN CERTIFICATE-----
+MIIEIzCCAwugAwIBAgICEAEwDQYJKoZIhvcNAQELBQAwgZ8xCzAJBgNVBAYTAlVT
+MRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRAwDgYDVQQK
+DAd3b2xmU1NMMRQwEgYDVQQLDAtEZXZlbG9wbWVudDEgMB4GA1UEAwwXd29sZlNT
+TCBJbnRlcm1lZGlhdGUgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5j
+b20wHhcNMjMwOTI3MTIxMDA5WhcNNDMwOTIyMTIxMDA5WjCBoDELMAkGA1UEBhMC
+VVMxEzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxEDAOBgNV
+BAoMB3dvbGZTU0wxFDASBgNVBAsMC0RldmVsb3BtZW50MSEwHwYDVQQDDBh3b2xm
+U1NMIEludGVybWVkaWF0ZTIgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNz
+bC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDPyT1ZAZ8dd5FW
+y6sGgsGBMZri+cb5o0AthkLXX0GlBUIPXytrvSmS5VLGXPl+nfuO1mmMA5GHHB+/
+JFlEzO+vkioG4aEBWwRXihq2BOLCPBA8QjEBqsPyMh4BldCRp2bBImg2UypSA+u1
+m4IBJPnRrvtTTFoG5W5a1qxbKBpT6Nelzm6cNMMIC8svjt/vjDX1sLxdD64KSs9U
+AdI8tHjuSBBWgE+Dh05nH08XLj4t9W3JB6I+MpIPHqQLVaYfhO+dde9mfHX350A6
+nMEzQj0vf5ldewTVqWxB6IkWWP06oAS9d9ZjXmoTWTdf8VkBRUici/cW9FD3WrRa
+M/b1QcE9AgMBAAGjZjBkMB0GA1UdDgQWBBQNyWAgQ1iB4Joh72YW3G4hJd8rRTAf
+BgNVHSMEGDAWgBTvaeD31R3mmezcbdD34rlcZHGDNTASBgNVHRMBAf8ECDAGAQH/
+AgEBMA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsFAAOCAQEAhsP4YtIQoLTa
+eOmFxZkEJJ53GliknybHWFu4doBXziCk5d4hIT1wAU0PbVr2PUho0jjF6tSfpACy
+5N5wa1i5oqmb3aamjmzE+V/XF0WFvugv+9KC0qss4v81ILRsBn4IUXqvGXNY86hI
+ZQpPZ0R+wP1LlJSxTFaFejGvCQP6zF2FVQusG2rJqsS75OCtQjjxb3TX2wzKAeDz
+Ssfr8m4wxo6jz1pFD3+YkjEg/CYhNBUGTymjXBURWwSU1SybHlthZdxubAAFAc4r
+SFT5kStMjLvblLUIUxGXFQG8ZSi2ooNf8Nh5hBcndSpUyAcx11AFUQdPV8i/SXU1
+oTmvZuwm4Q==
+-----END CERTIFICATE-----

--- a/examples/certs/client-int-cert.pem
+++ b/examples/certs/client-int-cert.pem
@@ -1,0 +1,88 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4099 (0x1003)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = wolfSSL Intermediate2 CA, emailAddress = info@wolfssl.com
+        Validity
+            Not Before: Sep 27 12:10:09 2023 GMT
+            Not After : Sep 24 12:10:09 2033 GMT
+        Subject: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = wolfSSL Client Chain, emailAddress = info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c3:03:d1:2b:fe:39:a4:32:45:3b:53:c8:84:2b:
+                    2a:7c:74:9a:bd:aa:2a:52:07:47:d6:a6:36:b2:07:
+                    32:8e:d0:ba:69:7b:c6:c3:44:9e:d4:81:48:fd:2d:
+                    68:a2:8b:67:bb:a1:75:c8:36:2c:4a:d2:1b:f7:8b:
+                    ba:cf:0d:f9:ef:ec:f1:81:1e:7b:9b:03:47:9a:bf:
+                    65:cc:7f:65:24:69:a6:e8:14:89:5b:e4:34:f7:c5:
+                    b0:14:93:f5:67:7b:3a:7a:78:e1:01:56:56:91:a6:
+                    13:42:8d:d2:3c:40:9c:4c:ef:d1:86:df:37:51:1b:
+                    0c:a1:3b:f5:f1:a3:4a:35:e4:e1:ce:96:df:1b:7e:
+                    bf:4e:97:d0:10:e8:a8:08:30:81:af:20:0b:43:14:
+                    c5:74:67:b4:32:82:6f:8d:86:c2:88:40:99:36:83:
+                    ba:1e:40:72:22:17:d7:52:65:24:73:b0:ce:ef:19:
+                    cd:ae:ff:78:6c:7b:c0:12:03:d4:4e:72:0d:50:6d:
+                    3b:a3:3b:a3:99:5e:9d:c8:d9:0c:85:b3:d9:8a:d9:
+                    54:26:db:6d:fa:ac:bb:ff:25:4c:c4:d1:79:f4:71:
+                    d3:86:40:18:13:b0:63:b5:72:4e:30:c4:97:84:86:
+                    2d:56:2f:d7:15:f7:7f:c0:ae:f5:fc:5b:e5:fb:a1:
+                    ba:d3
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            Netscape Cert Type: 
+                SSL Client, S/MIME
+            X509v3 Subject Key Identifier: 
+                33:D8:45:66:D7:68:87:18:7E:54:0D:70:27:91:C7:26:D7:85:65:C0
+            X509v3 Authority Key Identifier: 
+                0D:C9:60:20:43:58:81:E0:9A:21:EF:66:16:DC:6E:21:25:DF:2B:45
+            X509v3 Key Usage: critical
+                Digital Signature, Non Repudiation, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, E-mail Protection
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        c5:68:d3:86:36:7d:ce:fc:3d:fb:e6:44:1c:e6:60:9b:8a:43:
+        ec:e9:c9:ae:6c:90:6b:8e:45:d1:e4:1b:8e:08:42:89:2c:39:
+        81:c3:da:47:cd:5b:0b:d9:5b:d2:97:2b:6b:12:00:24:eb:e4:
+        0a:1d:b5:7c:50:e1:8c:c7:f3:ff:81:c7:8c:85:e5:50:0b:83:
+        1d:e0:aa:1c:72:8e:38:63:b1:f7:90:58:d2:9d:e3:a5:c3:03:
+        27:cb:f3:c9:ed:28:4f:61:9b:ea:09:65:d5:09:fc:f6:57:7e:
+        6f:70:55:13:66:fa:06:66:72:1c:da:4d:13:34:60:0b:87:9f:
+        2b:b2:56:ac:62:80:6e:e7:5a:30:a3:eb:2c:38:2c:a9:a8:7a:
+        08:b1:16:89:99:54:4c:8e:8b:30:f9:42:66:4f:5f:76:2b:a1:
+        85:99:dc:d6:a2:d5:35:58:7e:ab:e0:8b:9f:5b:6b:c1:e2:bc:
+        20:df:7a:cb:29:a7:dc:5e:9f:62:8a:63:f3:21:e6:19:5c:9a:
+        aa:75:26:f4:f1:a8:a9:57:39:e5:83:66:e4:56:d3:11:fd:3b:
+        fa:04:47:f3:df:e4:a0:b4:08:ec:4f:29:ff:ec:84:17:62:f7:
+        6d:79:cd:52:18:60:95:db:a1:1f:1a:80:11:26:73:db:de:eb:
+        47:5e:e4:ab
+-----BEGIN CERTIFICATE-----
+MIIESzCCAzOgAwIBAgICEAMwDQYJKoZIhvcNAQELBQAwgaAxCzAJBgNVBAYTAlVT
+MRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRAwDgYDVQQK
+DAd3b2xmU1NMMRQwEgYDVQQLDAtEZXZlbG9wbWVudDEhMB8GA1UEAwwYd29sZlNT
+TCBJbnRlcm1lZGlhdGUyIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wu
+Y29tMB4XDTIzMDkyNzEyMTAwOVoXDTMzMDkyNDEyMTAwOVowgZwxCzAJBgNVBAYT
+AlVTMRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRAwDgYD
+VQQKDAd3b2xmU1NMMRQwEgYDVQQLDAtEZXZlbG9wbWVudDEdMBsGA1UEAwwUd29s
+ZlNTTCBDbGllbnQgQ2hhaW4xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5j
+b20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDDA9Er/jmkMkU7U8iE
+Kyp8dJq9qipSB0fWpjayBzKO0Lppe8bDRJ7UgUj9LWiii2e7oXXINixK0hv3i7rP
+Dfnv7PGBHnubA0eav2XMf2UkaaboFIlb5DT3xbAUk/Vnezp6eOEBVlaRphNCjdI8
+QJxM79GG3zdRGwyhO/Xxo0o15OHOlt8bfr9Ol9AQ6KgIMIGvIAtDFMV0Z7Qygm+N
+hsKIQJk2g7oeQHIiF9dSZSRzsM7vGc2u/3hse8ASA9ROcg1QbTujO6OZXp3I2QyF
+s9mK2VQm2236rLv/JUzE0Xn0cdOGQBgTsGO1ck4wxJeEhi1WL9cV93/ArvX8W+X7
+obrTAgMBAAGjgZAwgY0wCQYDVR0TBAIwADARBglghkgBhvhCAQEEBAMCBaAwHQYD
+VR0OBBYEFDPYRWbXaIcYflQNcCeRxybXhWXAMB8GA1UdIwQYMBaAFA3JYCBDWIHg
+miHvZhbcbiEl3ytFMA4GA1UdDwEB/wQEAwIF4DAdBgNVHSUEFjAUBggrBgEFBQcD
+AgYIKwYBBQUHAwQwDQYJKoZIhvcNAQELBQADggEBAMVo04Y2fc78PfvmRBzmYJuK
+Q+zpya5skGuORdHkG44IQoksOYHD2kfNWwvZW9KXK2sSACTr5AodtXxQ4YzH8/+B
+x4yF5VALgx3gqhxyjjhjsfeQWNKd46XDAyfL88ntKE9hm+oJZdUJ/PZXfm9wVRNm
++gZmchzaTRM0YAuHnyuyVqxigG7nWjCj6yw4LKmoegixFomZVEyOizD5QmZPX3Yr
+oYWZ3Nai1TVYfqvgi59ba8HivCDfesspp9xen2KKY/Mh5hlcmqp1JvTxqKlXOeWD
+ZuRW0xH9O/oER/Pf5KC0COxPKf/shBdi9215zVIYYJXboR8agBEmc9ve60de5Ks=
+-----END CERTIFICATE-----

--- a/examples/certs/server-cert.pem
+++ b/examples/certs/server-cert.pem
@@ -5,12 +5,12 @@ Certificate:
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Validity
-            Not Before: Feb 15 12:50:24 2022 GMT
-            Not After : Nov 11 12:50:24 2024 GMT
+            Not Before: Dec 18 21:25:30 2024 GMT
+            Not After : Sep 14 21:25:30 2027 GMT
         Subject: C = US, ST = Montana, L = Bozeman, O = wolfSSL, OU = Support, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
                     00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
                     01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
@@ -37,8 +37,7 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:26:8C:93:F9:F9:F4:1E:B3:01:72:94:55:67:6D:E2:F8:3D:DA:E9:F4
-
+                serial:6B:9B:70:C6:F1:A3:94:65:19:A1:08:58:EF:A7:8D:2B:7A:83:C1:DA
             X509v3 Basic Constraints: 
                 CA:TRUE
             X509v3 Subject Alternative Name: 
@@ -46,27 +45,28 @@ Certificate:
             X509v3 Extended Key Usage: 
                 TLS Web Server Authentication, TLS Web Client Authentication
     Signature Algorithm: sha256WithRSAEncryption
-         4b:88:54:a8:57:f0:62:4d:b3:c5:8c:d2:02:0a:89:19:45:63:
-         8e:37:5c:a9:f7:8c:c5:7c:9d:19:b4:5d:b6:a4:29:4d:97:da:
-         6e:3c:27:ec:02:5c:fb:e2:93:6f:b6:1a:dc:5e:25:1f:be:ab:
-         6f:37:ff:d6:98:67:7c:f7:53:84:3b:e6:f7:22:ef:52:b0:8f:
-         9d:4e:2f:41:2a:7d:2f:f8:02:1e:f5:cd:9a:b2:68:68:d6:ef:
-         ed:6a:96:a0:84:6f:0c:5e:7b:44:f9:6f:d0:00:6f:dd:83:6a:
-         d9:d9:17:9d:32:9a:ea:4b:87:f9:12:45:3e:b8:de:20:fe:f4:
-         b8:3f:f4:99:61:a6:2b:97:1b:7c:a0:90:cf:e9:3b:cd:94:ce:
-         85:df:fb:6a:2b:67:5b:8c:28:de:e6:0b:4b:68:5b:b3:4a:3e:
-         10:3b:0c:d8:c8:f1:3e:3d:cc:2f:16:76:24:43:b6:3b:fd:cf:
-         2f:07:0f:15:31:59:5e:cd:84:a9:82:05:1f:0c:97:56:5d:90:
-         49:bd:84:47:ec:07:b9:cf:fa:a0:56:9b:ae:e2:a9:96:b2:62:
-         02:4a:fa:42:d5:23:dc:1c:6b:5c:41:3d:f2:73:e8:ed:32:93:
-         cc:f7:02:5a:b4:be:84:ca:73:26:9f:03:2c:b3:74:96:20:7e:
-         12:ea:e5:ef
+    Signature Value:
+        8a:f1:4e:e8:9f:59:b2:d9:13:ac:fc:42:c4:81:34:9f:6b:39:
+        57:9c:e9:92:5d:41:ac:05:35:b1:26:93:4d:4a:da:f8:51:82:
+        d2:8d:7f:d3:5c:6e:29:80:8d:9b:02:10:2b:64:f5:d1:31:06:
+        fa:85:2b:8f:63:32:14:76:7a:39:15:f3:4e:dd:fd:e2:2c:90:
+        15:d1:6f:73:87:ee:e6:c8:eb:ad:40:d5:e8:94:1f:a6:7e:26:
+        5b:87:ba:0f:06:5a:4d:55:7a:aa:c4:09:34:8b:f7:e5:cc:d6:
+        b7:6c:46:6d:a1:e6:66:66:4c:4b:e5:12:31:37:54:49:64:a5:
+        66:eb:e0:c6:a1:49:f8:4d:c3:d3:55:a4:05:d2:ac:fb:e1:c8:
+        69:30:4b:98:fd:72:1a:ab:9f:86:eb:0d:bd:7c:a6:3d:81:d9:
+        01:a7:8a:79:ab:3c:ce:e5:b6:c3:1b:ef:7d:5e:37:7b:37:7c:
+        91:89:59:11:21:11:7c:05:80:e1:a8:d6:f9:35:da:1b:86:06:
+        5a:32:67:6c:a9:2b:e0:31:7b:89:53:37:42:af:34:a4:53:d2:
+        7c:91:50:63:3a:8e:4a:1f:a3:90:4e:7c:41:59:1d:eb:7b:a2:
+        14:87:ba:76:36:a4:77:46:34:f2:55:50:f0:24:9f:83:83:da:
+        a6:aa:3c:c8
 -----BEGIN CERTIFICATE-----
 MIIE6DCCA9CgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMCVVMx
 EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
 d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
-bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMjIwMjE1
-MTI1MDI0WhcNMjQxMTExMTI1MDI0WjCBkDELMAkGA1UEBhMCVVMxEDAOBgNVBAgM
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMjQxMjE4
+MjEyNTMwWhcNMjcwOTE0MjEyNTMwWjCBkDELMAkGA1UEBhMCVVMxEDAOBgNVBAgM
 B01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xEDAOBgNVBAoMB3dvbGZTU0wxEDAO
 BgNVBAsMB1N1cHBvcnQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
 SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP
@@ -80,30 +80,30 @@ BBSzETLJkpiE4sn40DtuA0LKHw6OPDCB1AYDVR0jBIHMMIHJgBQnjmcRdMMmHT/t
 M2OzpNgdMOXo1aGBmqSBlzCBlDELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRh
 bmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3RoMRMwEQYDVQQL
 DApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG
-9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CFCaMk/n59B6zAXKUVWdt4vg92un0MAwG
+9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CFGubcMbxo5RlGaEIWO+njSt6g8HaMAwG
 A1UdEwQFMAMBAf8wHAYDVR0RBBUwE4ILZXhhbXBsZS5jb22HBH8AAAEwHQYDVR0l
-BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA0GCSqGSIb3DQEBCwUAA4IBAQBLiFSo
-V/BiTbPFjNICCokZRWOON1yp94zFfJ0ZtF22pClNl9puPCfsAlz74pNvthrcXiUf
-vqtvN//WmGd891OEO+b3Iu9SsI+dTi9BKn0v+AIe9c2asmho1u/tapaghG8MXntE
-+W/QAG/dg2rZ2RedMprqS4f5EkU+uN4g/vS4P/SZYaYrlxt8oJDP6TvNlM6F3/tq
-K2dbjCje5gtLaFuzSj4QOwzYyPE+PcwvFnYkQ7Y7/c8vBw8VMVlezYSpggUfDJdW
-XZBJvYRH7Ae5z/qgVpuu4qmWsmICSvpC1SPcHGtcQT3yc+jtMpPM9wJatL6EynMm
-nwMss3SWIH4S6uXv
+BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA0GCSqGSIb3DQEBCwUAA4IBAQCK8U7o
+n1my2ROs/ELEgTSfazlXnOmSXUGsBTWxJpNNStr4UYLSjX/TXG4pgI2bAhArZPXR
+MQb6hSuPYzIUdno5FfNO3f3iLJAV0W9zh+7myOutQNXolB+mfiZbh7oPBlpNVXqq
+xAk0i/flzNa3bEZtoeZmZkxL5RIxN1RJZKVm6+DGoUn4TcPTVaQF0qz74chpMEuY
+/XIaq5+G6w29fKY9gdkBp4p5qzzO5bbDG+99Xjd7N3yRiVkRIRF8BYDhqNb5Ndob
+hgZaMmdsqSvgMXuJUzdCrzSkU9J8kVBjOo5KH6OQTnxBWR3re6IUh7p2NqR3RjTy
+VVDwJJ+Dg9qmqjzI
 -----END CERTIFICATE-----
 Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            26:8c:93:f9:f9:f4:1e:b3:01:72:94:55:67:6d:e2:f8:3d:da:e9:f4
+            6b:9b:70:c6:f1:a3:94:65:19:a1:08:58:ef:a7:8d:2b:7a:83:c1:da
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Validity
-            Not Before: Feb 15 12:50:24 2022 GMT
-            Not After : Nov 11 12:50:24 2024 GMT
+            Not Before: Dec 18 21:25:29 2024 GMT
+            Not After : Sep 14 21:25:29 2027 GMT
         Subject: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
                     00:bf:0c:ca:2d:14:b2:1e:84:42:5b:cd:38:1f:4a:
                     f2:4d:75:10:f1:b6:35:9f:df:ca:7d:03:98:d3:ac:
@@ -130,8 +130,7 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:26:8C:93:F9:F9:F4:1E:B3:01:72:94:55:67:6D:E2:F8:3D:DA:E9:F4
-
+                serial:6B:9B:70:C6:F1:A3:94:65:19:A1:08:58:EF:A7:8D:2B:7A:83:C1:DA
             X509v3 Basic Constraints: 
                 CA:TRUE
             X509v3 Subject Alternative Name: 
@@ -139,27 +138,28 @@ Certificate:
             X509v3 Extended Key Usage: 
                 TLS Web Server Authentication, TLS Web Client Authentication
     Signature Algorithm: sha256WithRSAEncryption
-         62:e4:1b:28:3c:9d:d2:60:a9:55:be:6a:f6:20:f2:da:e8:a1:
-         1a:97:b1:90:77:82:ed:c7:77:29:53:33:18:10:62:e0:bd:93:
-         1b:d2:d6:a1:80:43:1d:64:f1:42:92:ec:b7:b8:f0:6b:da:59:
-         83:f4:b8:87:e6:fc:70:21:ea:62:32:70:68:14:0e:dc:b4:f1:
-         66:e2:6e:ab:d2:72:6f:da:df:71:f6:3d:27:97:7d:be:e1:d1:
-         ac:16:ad:d7:4f:aa:9d:0c:1e:6e:a9:5e:7d:57:5b:3c:c7:6d:
-         d2:f2:5c:c3:dc:3d:36:99:8e:ab:c0:7f:13:a5:f4:67:8b:e2:
-         a6:51:31:f1:03:91:00:a8:c4:c5:1d:7f:35:62:b8:1d:a0:a5:
-         ab:ec:32:68:ee:f3:ca:48:16:9f:f4:1e:7e:ea:fa:b0:86:15:
-         52:36:6c:4b:58:44:a7:eb:20:78:6e:7e:e8:00:40:ac:98:d8:
-         53:f3:13:4b:b8:98:66:50:63:ed:af:e5:a4:f6:c9:90:1c:84:
-         0a:09:45:2f:a1:e1:37:63:b5:43:8c:a0:2e:7f:c4:d4:e1:ae:
-         b7:b9:45:13:f8:70:d5:79:06:4f:82:83:4b:98:d7:56:47:64:
-         9a:6a:6d:8e:7a:9d:ef:83:0f:6b:75:0e:47:22:92:f3:b4:b2:
-         84:61:1f:1c
+    Signature Value:
+        77:3b:3d:66:74:bc:97:fe:40:16:e6:ba:a5:d5:d1:84:08:89:
+        69:4f:88:0d:57:a9:ef:8c:c3:97:52:c8:bd:8b:a2:49:3b:b7:
+        f7:5d:1e:d6:14:7f:b2:80:33:da:a0:8a:d3:e1:2f:d5:bc:33:
+        9f:ea:5a:72:24:e5:f8:b8:4b:b3:df:62:90:3b:a8:21:ef:27:
+        42:75:bc:60:02:8e:37:35:99:eb:a3:28:f2:65:4c:ff:7a:f8:
+        8e:cc:23:6d:e5:6a:fe:22:5a:d9:b2:4f:47:c7:e0:ae:98:ef:
+        94:ac:b6:4f:61:81:29:8e:e1:79:2c:46:fc:e9:1a:c3:96:1f:
+        19:93:64:2e:9f:37:72:c5:e4:93:4e:61:5f:38:8e:ae:e8:39:
+        19:e6:97:a8:91:d4:23:7e:1e:d2:d0:53:ec:cc:ac:a0:1d:d0:
+        b7:dd:b1:b7:01:2e:96:cd:85:27:e0:e7:47:e2:c1:c1:00:f6:
+        94:df:77:e7:fa:c6:ef:8a:c0:7c:67:bc:ff:a0:7c:94:3b:7d:
+        86:42:af:3d:83:31:ee:2a:3b:7b:f0:2c:9e:6f:e9:c4:07:81:
+        24:da:05:70:4d:dd:09:ae:9e:72:b8:21:0e:8c:b2:ab:aa:4c:
+        49:10:f7:76:f9:b5:0d:6c:20:d3:df:7a:06:32:8d:29:1f:28:
+        1d:8d:26:33
 -----BEGIN CERTIFICATE-----
-MIIE/zCCA+egAwIBAgIUJoyT+fn0HrMBcpRVZ23i+D3a6fQwDQYJKoZIhvcNAQEL
+MIIE/zCCA+egAwIBAgIUa5twxvGjlGUZoQhY76eNK3qDwdowDQYJKoZIhvcNAQEL
 BQAwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
 b3plbWFuMREwDwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEY
 MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdv
-bGZzc2wuY29tMB4XDTIyMDIxNTEyNTAyNFoXDTI0MTExMTEyNTAyNFowgZQxCzAJ
+bGZzc2wuY29tMB4XDTI0MTIxODIxMjUyOVoXDTI3MDkxNDIxMjUyOVowgZQxCzAJ
 BgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREw
 DwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwP
 d3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29t
@@ -174,12 +174,12 @@ BgNVHSMEgcwwgcmAFCeOZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8G
 A1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3
 dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIU
-JoyT+fn0HrMBcpRVZ23i+D3a6fQwDAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtl
+a5twxvGjlGUZoQhY76eNK3qDwdowDAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtl
 eGFtcGxlLmNvbYcEfwAAATAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
-DQYJKoZIhvcNAQELBQADggEBAGLkGyg8ndJgqVW+avYg8trooRqXsZB3gu3HdylT
-MxgQYuC9kxvS1qGAQx1k8UKS7Le48GvaWYP0uIfm/HAh6mIycGgUDty08WbibqvS
-cm/a33H2PSeXfb7h0awWrddPqp0MHm6pXn1XWzzHbdLyXMPcPTaZjqvAfxOl9GeL
-4qZRMfEDkQCoxMUdfzViuB2gpavsMmju88pIFp/0Hn7q+rCGFVI2bEtYRKfrIHhu
-fugAQKyY2FPzE0u4mGZQY+2v5aT2yZAchAoJRS+h4TdjtUOMoC5/xNThrre5RRP4
-cNV5Bk+Cg0uY11ZHZJpqbY56ne+DD2t1DkcikvO0soRhHxw=
+DQYJKoZIhvcNAQELBQADggEBAHc7PWZ0vJf+QBbmuqXV0YQIiWlPiA1Xqe+Mw5dS
+yL2Lokk7t/ddHtYUf7KAM9qgitPhL9W8M5/qWnIk5fi4S7PfYpA7qCHvJ0J1vGAC
+jjc1meujKPJlTP96+I7MI23lav4iWtmyT0fH4K6Y75Sstk9hgSmO4XksRvzpGsOW
+HxmTZC6fN3LF5JNOYV84jq7oORnml6iR1CN+HtLQU+zMrKAd0LfdsbcBLpbNhSfg
+50fiwcEA9pTfd+f6xu+KwHxnvP+gfJQ7fYZCrz2DMe4qO3vwLJ5v6cQHgSTaBXBN
+3QmunnK4IQ6MsquqTEkQ93b5tQ1sINPfegYyjSkfKB2NJjM=
 -----END CERTIFICATE-----

--- a/examples/certs/server-ecc.pem
+++ b/examples/certs/server-ecc.pem
@@ -1,0 +1,57 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+        Validity
+            Not Before: Dec 18 21:25:30 2024 GMT
+            Not After : Sep 14 21:25:30 2027 GMT
+        Subject: C = US, ST = Washington, L = Seattle, O = Elliptic, OU = ECC, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:bb:33:ac:4c:27:50:4a:c6:4a:a5:04:c3:3c:de:
+                    9f:36:db:72:2d:ce:94:ea:2b:fa:cb:20:09:39:2c:
+                    16:e8:61:02:e9:af:4d:d3:02:93:9a:31:5b:97:92:
+                    21:7f:f0:cf:18:da:91:11:02:34:86:e8:20:58:33:
+                    0b:80:34:89:d8
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                5D:5D:26:EF:AC:7E:36:F9:9B:76:15:2B:4A:25:02:23:EF:B2:89:30
+            X509v3 Authority Key Identifier: 
+                56:8E:9A:C3:F0:42:DE:18:B9:45:55:6E:F9:93:CF:EA:C3:F3:A5:21
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment, Key Agreement
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication
+            Netscape Cert Type: 
+                SSL Server
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:21:00:8b:82:a5:d2:f6:ca:84:ba:ad:2d:de:36:e9:
+        2a:4d:ee:4b:20:46:ba:ab:4e:d0:10:6e:eb:30:b6:7e:d8:af:
+        8c:02:20:06:74:40:6a:a9:31:54:fe:20:9d:c6:6d:2b:df:1d:
+        aa:63:da:fc:97:50:87:92:69:ee:63:57:b6:ec:e2:e9:fa
+-----BEGIN CERTIFICATE-----
+MIICojCCAkigAwIBAgIBAzAKBggqhkjOPQQDAjCBlzELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxEDAOBgNVBAoMB3dv
+bGZTU0wxFDASBgNVBAsMC0RldmVsb3BtZW50MRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMjQxMjE4
+MjEyNTMwWhcNMjcwOTE0MjEyNTMwWjCBkDELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxETAPBgNVBAoMCEVsbGlwdGlj
+MQwwCgYDVQQLDANFQ0MxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
+SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABLszrEwnUErGSqUEwzzenzbbci3OlOor+ssgCTksFuhhAumvTdMCk5oxW5eS
+IX/wzxjakRECNIboIFgzC4A0idijgYkwgYYwHQYDVR0OBBYEFF1dJu+sfjb5m3YV
+K0olAiPvsokwMB8GA1UdIwQYMBaAFFaOmsPwQt4YuUVVbvmTz+rD86UhMAwGA1Ud
+EwEB/wQCMAAwDgYDVR0PAQH/BAQDAgOoMBMGA1UdJQQMMAoGCCsGAQUFBwMBMBEG
+CWCGSAGG+EIBAQQEAwIGQDAKBggqhkjOPQQDAgNIADBFAiEAi4Kl0vbKhLqtLd42
+6SpN7ksgRrqrTtAQbuswtn7Yr4wCIAZ0QGqpMVT+IJ3GbSvfHapj2vyXUIeSae5j
+V7bs4un6
+-----END CERTIFICATE-----

--- a/examples/x509/certVerify.go
+++ b/examples/x509/certVerify.go
@@ -1,0 +1,121 @@
+/* certVerify.go
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+    	wolfSSL "github.com/wolfssl/go-wolfssl"
+)
+
+func readFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %v", path, err)
+	}
+	return data, nil
+}
+
+func loadX509(certData []byte) *wolfSSL.WOLFSSL_X509 {
+	ret := wolfSSL.WolfSSL_X509_load_certificate_buffer(certData, len(certData), wolfSSL.SSL_FILETYPE_PEM)
+	return ret
+}
+
+func main() {
+	caPath   := "../certs/ca-cert.pem"
+	int1Path := "../certs/ca-int-cert.pem"
+	int2Path := "../certs/ca-int2-cert.pem"
+	leafPath := "../certs/client-int-cert.pem"
+
+
+	int1Cert, err := readFile(int1Path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	int2Cert, err := readFile(int2Path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	leafCert, err := readFile(leafPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Convert to internal WOLFSSL_X509
+	x509Int1 := loadX509(int1Cert)
+	x509Int2 := loadX509(int2Cert)
+	x509Leaf := loadX509(leafCert)
+	if x509Int1 == nil || x509Int2 == nil || x509Leaf == nil {
+		fmt.Fprintln(os.Stderr, "Error converting one or more certificates to wolfSSL X509")
+		os.Exit(1)
+	}
+
+	// Create store and load CA file
+	store := wolfSSL.WolfSSL_X509_STORE_new()
+	if store == nil {
+		fmt.Fprintln(os.Stderr, "Failed to create X509 store")
+		os.Exit(1)
+	}
+	defer wolfSSL.WolfSSL_X509_STORE_free(store)
+
+	if ret := wolfSSL.WolfSSL_X509_STORE_load_file(store, caPath); ret != 1 {
+		fmt.Fprintln(os.Stderr, "Failed to load CA cert into store")
+		os.Exit(1)
+	}
+
+	// Create stack for intermediates
+	inter := wolfSSL.WolfSSL_sk_X509_new_null()
+	if inter == nil {
+		fmt.Fprintln(os.Stderr, "Failed to create intermediate cert stack")
+		os.Exit(1)
+	}
+	defer wolfSSL.WolfSSL_sk_X509_free(inter)
+
+	wolfSSL.WolfSSL_sk_X509_push(inter, x509Int1)
+	wolfSSL.WolfSSL_sk_X509_push(inter, x509Int2)
+
+	// Setup store context
+	ctx := wolfSSL.WolfSSL_X509_STORE_CTX_new()
+	if ctx == nil {
+		fmt.Fprintln(os.Stderr, "Failed to create X509_STORE_CTX")
+		os.Exit(1)
+	}
+	defer wolfSSL.WolfSSL_X509_STORE_CTX_free(ctx)
+
+	if ret := wolfSSL.WolfSSL_X509_STORE_CTX_init(ctx, store, x509Leaf, inter); ret != 1 {
+		fmt.Fprintln(os.Stderr, "X509_STORE_CTX_init failed")
+		os.Exit(1)
+	}
+
+	// Perform verification
+	if ret := wolfSSL.WolfSSL_X509_verify_cert(ctx); ret != 1 {
+		fmt.Fprintln(os.Stderr, "Certificate verification FAILED")
+		os.Exit(1)
+	}
+
+	fmt.Println("Certificate chain verified successfully.")
+}
+

--- a/examples/x509/extractKey.go
+++ b/examples/x509/extractKey.go
@@ -1,0 +1,102 @@
+/* extractKey.go
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+    	wolfSSL "github.com/wolfssl/go-wolfssl"
+)
+
+func readFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %v", path, err)
+	}
+	return data, nil
+}
+
+func loadX509(certData []byte) *wolfSSL.WOLFSSL_X509 {
+	ret := wolfSSL.WolfSSL_X509_load_certificate_buffer(certData, len(certData), wolfSSL.SSL_FILETYPE_PEM)
+	return ret
+}
+
+func main() {
+	leafPath := "../certs/server-ecc.pem"
+
+
+	leafCert, err := readFile(leafPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Convert to internal WOLFSSL_X509
+	x509Leaf := loadX509(leafCert)
+	if x509Leaf == nil {
+		fmt.Fprintln(os.Stderr, "Error converting one or more certificates to wolfSSL X509")
+		os.Exit(1)
+	}
+
+	// First call to get required buffer size
+	var pubLen int
+	ret := wolfSSL.WolfSSL_X509_get_pubkey_buffer(x509Leaf, nil, &pubLen)
+	if ret != 1 || pubLen <= 0 {
+		fmt.Fprintln(os.Stderr, "Failed to determine public key buffer size")
+		os.Exit(1)
+	}
+
+	// Allocate buffer and extract public key
+	pubBuf := make([]byte, pubLen)
+	ret = wolfSSL.WolfSSL_X509_get_pubkey_buffer(x509Leaf, pubBuf, &pubLen)
+	if ret != 1 {
+		fmt.Fprintln(os.Stderr, "Failed to extract public key from leaf certificate")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Extracted leaf cert public key DER (%d bytes):\n", pubLen)
+	fmt.Printf("%x\n", pubBuf)
+
+	digest := make([]byte, wolfSSL.WC_SHA384_DIGEST_SIZE )
+        wolfSSL.Wc_Sha384Hash(pubBuf, pubLen, digest)
+	fmt.Printf("SHA484 hash of public key DER\n")
+	fmt.Printf("%x\n", digest)
+
+	var pubKey wolfSSL.Ecc_key
+	if ret = wolfSSL.Wc_ecc_init(&pubKey); ret != 0 {
+		fmt.Fprintln(os.Stderr, "Failed to initialize ECC key")
+		os.Exit(1)
+        }
+
+	idx := 0
+	if ret = wolfSSL.Wc_EccPublicKeyDecode(pubBuf, &idx, &pubKey, pubLen); ret != 0 {
+		print("Return is ",ret)
+		fmt.Fprintln(os.Stderr, "Failed to import DER buffer into ECC key")
+		os.Exit(1)
+        }
+	
+	fmt.Println("Successfully imported ECC public key structure from DER buffer")
+        
+	wolfSSL.Wc_ecc_free(&pubKey)
+}
+

--- a/fips.go
+++ b/fips.go
@@ -1,6 +1,6 @@
 /* fips.go
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/hash.go
+++ b/hash.go
@@ -1,6 +1,6 @@
 /* hash.go
  *
- * Copyright (C) 2006-2022 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/hmac.go
+++ b/hmac.go
@@ -1,6 +1,6 @@
 /* hmac.go
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/misc.go
+++ b/misc.go
@@ -1,6 +1,6 @@
 /* misc.go
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/random.go
+++ b/random.go
@@ -1,6 +1,6 @@
 /* random.go
  *
- * Copyright (C) 2006-2022 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/sha.go
+++ b/sha.go
@@ -1,6 +1,6 @@
 /* sha.go
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/ssl.go
+++ b/ssl.go
@@ -1,6 +1,6 @@
 /* ssl.go
  *
- * Copyright (C) 2006-2022 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/ssl.go
+++ b/ssl.go
@@ -66,6 +66,7 @@ import (
 )
 
 const SSL_FILETYPE_PEM = 1
+const SSL_FILETYPE_ASN1 = 2
 const WOLFSSL_SUCCESS  = 1
 
 type WOLFSSL = C.struct_WOLFSSL

--- a/x509.go
+++ b/x509.go
@@ -31,18 +31,19 @@ package wolfSSL
 // typedef struct WOLFSSL_X509 {} WOLFSSL_X509;
 // typedef struct WOLFSSL_X509_STORE {} WOLFSSL_X509_STORE;
 // typedef struct WOLFSSL_STACK {} WOLFSSL_STACK;
-// static WOLFSSL_X509_STORE* X509_STORE_new(void) { return 0; }
+// static WOLFSSL_X509_STORE* X509_STORE_new(void) { return NULL; }
 // static void X509_STORE_free(WOLFSSL_X509_STORE* s) { (void)s; }
 // static int X509_STORE_load_locations(WOLFSSL_X509_STORE* s, const char* file, const char* path) { return -174; }
-// static WOLFSSL_STACK* sk_X509_new_null(void) { return 0; }
+// static WOLFSSL_STACK* sk_X509_new_null(void) { return NULL; }
 // static int sk_X509_push(WOLFSSL_STACK* sk, WOLFSSL_X509* cert) { return -174; }
 // static void sk_X509_free(WOLFSSL_STACK* sk) { (void)sk; }
-// static WOLFSSL_X509_STORE_CTX* X509_STORE_CTX_new(void) { return 0; }
+// static WOLFSSL_X509_STORE_CTX* X509_STORE_CTX_new(void) { return NULL; }
 // static void X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx) { (void)ctx; }
 // static int X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx, WOLFSSL_X509_STORE* store,
 //                                 WOLFSSL_X509* cert, WOLFSSL_STACK* chain) { return -174; }
 // static int X509_verify_cert(WOLFSSL_X509_STORE_CTX* ctx) { return -174; }
-// static WOLFSSL_X509* wolfSSL_X509_load_certificate_buffer(const unsigned char* buff, int sz, int type) { return 0; }
+// static WOLFSSL_X509* wolfSSL_X509_load_certificate_buffer(const unsigned char* buff, int sz, int type) { return NULL; }
+// static int wolfSSL_X509_get_pubkey_buffer(WOLFSSL_X509* x509, unsigned char* buf, int* bufSz) { return -174; }
 // #endif
 import "C"
 import (
@@ -106,4 +107,11 @@ func WolfSSL_X509_load_certificate_buffer(buff []byte, buffSz int, certType int)
 	return C.wolfSSL_X509_load_certificate_buffer((*C.byte)(unsafe.Pointer(&buff[0])), C.int(buffSz), C.int(certType))
 }
 
+func WolfSSL_X509_get_pubkey_buffer(cert *WOLFSSL_X509, out []byte, outLen *int) int {
+	var outPtr *C.uchar
+	if len(out) > 0 {
+		outPtr = (*C.uchar)(unsafe.Pointer(&out[0]))
+	}
+	return int(C.wolfSSL_X509_get_pubkey_buffer(cert, outPtr, (*C.int)(unsafe.Pointer(outLen))))
+}
 

--- a/x509.go
+++ b/x509.go
@@ -1,0 +1,109 @@
+/* x509.go
+ *
+ * Copyright (C) 2006-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+package wolfSSL
+
+// #include <wolfssl/options.h>
+// #include <wolfssl/openssl/x509.h>
+// #include <wolfssl/openssl/x509_vfy.h>
+// #include <wolfssl/openssl/ssl.h>
+// #include <wolfssl/openssl/stack.h>
+// #include <wolfssl/openssl/bio.h>
+// #ifndef OPENSSL_ALL
+// typedef struct WOLFSSL_X509 {} WOLFSSL_X509;
+// typedef struct WOLFSSL_X509_STORE {} WOLFSSL_X509_STORE;
+// typedef struct WOLFSSL_STACK {} WOLFSSL_STACK;
+// static WOLFSSL_X509_STORE* X509_STORE_new(void) { return 0; }
+// static void X509_STORE_free(WOLFSSL_X509_STORE* s) { (void)s; }
+// static int X509_STORE_load_locations(WOLFSSL_X509_STORE* s, const char* file, const char* path) { return -174; }
+// static WOLFSSL_STACK* sk_X509_new_null(void) { return 0; }
+// static int sk_X509_push(WOLFSSL_STACK* sk, WOLFSSL_X509* cert) { return -174; }
+// static void sk_X509_free(WOLFSSL_STACK* sk) { (void)sk; }
+// static WOLFSSL_X509_STORE_CTX* X509_STORE_CTX_new(void) { return 0; }
+// static void X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx) { (void)ctx; }
+// static int X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx, WOLFSSL_X509_STORE* store,
+//                                 WOLFSSL_X509* cert, WOLFSSL_STACK* chain) { return -174; }
+// static int X509_verify_cert(WOLFSSL_X509_STORE_CTX* ctx) { return -174; }
+// static WOLFSSL_X509* wolfSSL_X509_load_certificate_buffer(const unsigned char* buff, int sz, int type) { return 0; }
+// #endif
+import "C"
+import (
+    "unsafe"
+)
+
+type WOLFSSL_X509 = C.struct_WOLFSSL_X509
+
+// X509_STORE wrappers
+func WolfSSL_X509_STORE_new() *C.WOLFSSL_X509_STORE {
+	return C.X509_STORE_new()
+}
+
+func WolfSSL_X509_STORE_free(store *C.WOLFSSL_X509_STORE) {
+	C.X509_STORE_free(store)
+}
+
+func WolfSSL_X509_STORE_load_locations(store *C.WOLFSSL_X509_STORE, capath string) int {
+	cStr := C.CString(capath)
+	defer C.free(unsafe.Pointer(cStr))
+	return int(C.X509_STORE_load_locations(store, nil, cStr))
+}
+
+func WolfSSL_X509_STORE_load_file(store *C.WOLFSSL_X509_STORE, cafile string) int {
+	cStr := C.CString(cafile)
+	defer C.free(unsafe.Pointer(cStr))
+	return int(C.X509_STORE_load_locations(store, cStr, nil))
+}
+
+// WOLFSSL_STACK (used as sk_X509*)
+func WolfSSL_sk_X509_new_null() *C.WOLFSSL_STACK {
+	return C.sk_X509_new_null()
+}
+
+func WolfSSL_sk_X509_push(stack *C.WOLFSSL_STACK, cert *C.WOLFSSL_X509) int {
+	return int(C.sk_X509_push(stack, cert))
+}
+
+func WolfSSL_sk_X509_free(stack *C.WOLFSSL_STACK) {
+	C.sk_X509_free(stack)
+}
+
+// X509_STORE_CTX
+func WolfSSL_X509_STORE_CTX_new() *C.WOLFSSL_X509_STORE_CTX {
+	return C.X509_STORE_CTX_new()
+}
+
+func WolfSSL_X509_STORE_CTX_free(ctx *C.WOLFSSL_X509_STORE_CTX) {
+	C.X509_STORE_CTX_free(ctx)
+}
+
+func WolfSSL_X509_STORE_CTX_init(ctx *C.WOLFSSL_X509_STORE_CTX, store *C.WOLFSSL_X509_STORE, cert *C.WOLFSSL_X509, chain *C.WOLFSSL_STACK) int {
+	return int(C.X509_STORE_CTX_init(ctx, store, cert, chain))
+}
+
+func WolfSSL_X509_verify_cert(ctx *C.WOLFSSL_X509_STORE_CTX) int {
+	return int(C.X509_verify_cert(ctx))
+}
+
+func WolfSSL_X509_load_certificate_buffer(buff []byte, buffSz int, certType int) *C.WOLFSSL_X509 {
+	return C.wolfSSL_X509_load_certificate_buffer((*C.byte)(unsafe.Pointer(&buff[0])), C.int(buffSz), C.int(certType))
+}
+
+


### PR DESCRIPTION
Mainly adds api's needed for cert verification via OpenSSL compat layer, and also API's needed to extract/use the public key from an X509 cert. The PR also includes new examples for demonstrating both.