### PR TITLE
Fenrir fixes

### DIFF
--- a/aes.go
+++ b/aes.go
@@ -154,15 +154,18 @@ func Wc_AesFree(aes *C.struct_Aes) {
 
 func Wc_AesSetKey(aes *C.struct_Aes, key []byte, length int, iv []byte, dir int) int {
     if length < 0 || length > len(key) { return BAD_FUNC_ARG }
-    if len(key) == 0 || len(iv) < AES_IV_SIZE { return BAD_FUNC_ARG }
+    if len(key) == 0 { return BAD_FUNC_ARG }
+    var ivPtr *C.uchar
+    if len(iv) > 0 {
+        ivPtr = (*C.uchar)(unsafe.Pointer(&iv[0]))
+    }
     return int(C.wc_AesSetKey(aes, (*C.uchar)(unsafe.Pointer(&key[0])), C.word32(length),
-               (*C.uchar)(unsafe.Pointer(&iv[0])), C.int(dir)))
+               ivPtr, C.int(dir)))
 }
 
 func Wc_AesCbcEncrypt(aes *C.struct_Aes, out []byte, in []byte, sz int) int {
     if sz < 0 || sz > len(in) || sz > len(out) { return BAD_FUNC_ARG }
     if sz == 0 { return 0 }
-    if sz%AES_BLOCK_SIZE != 0 { return BAD_FUNC_ARG }
     return int(C.wc_AesCbcEncrypt(aes, (*C.uchar)(unsafe.Pointer(&out[0])),
                (*C.uchar)(unsafe.Pointer(&in[0])), C.word32(sz)))
 }
@@ -170,7 +173,6 @@ func Wc_AesCbcEncrypt(aes *C.struct_Aes, out []byte, in []byte, sz int) int {
 func Wc_AesCbcDecrypt(aes *C.struct_Aes, out []byte, in []byte, sz int) int {
     if sz < 0 || sz > len(in) || sz > len(out) { return BAD_FUNC_ARG }
     if sz == 0 { return 0 }
-    if sz%AES_BLOCK_SIZE != 0 { return BAD_FUNC_ARG }
     return int(C.wc_AesCbcDecrypt(aes, (*C.uchar)(unsafe.Pointer(&out[0])),
                (*C.uchar)(unsafe.Pointer(&in[0])), C.word32(sz)))
 }

--- a/blake2.go
+++ b/blake2.go
@@ -87,6 +87,9 @@ func Wc_Blake2sFinal(blake2s *C.struct_Blake2s, out []byte, requestSz int) int {
 }
 
 func Wc_Blake2s_HMAC(out []byte, in, key []byte, outlen int) {
+    if outlen != WC_BLAKE2S_256_DIGEST_SIZE || len(out) < outlen {
+        return
+    }
     zeroMemory(out)
 
     var state Blake2s
@@ -102,10 +105,6 @@ func Wc_Blake2s_HMAC(out []byte, in, key []byte, outlen int) {
 
     inlen := len(in)
     keylen := len(key)
-
-    if outlen != WC_BLAKE2S_256_DIGEST_SIZE || len(out) < outlen {
-        return
-    }
 
     if keylen > WC_BLAKE2S_256_BLOCK_SIZE {
         ret = Wc_InitBlake2s(&state, WC_BLAKE2S_256_DIGEST_SIZE)

--- a/chacha_poly.go
+++ b/chacha_poly.go
@@ -147,9 +147,7 @@ func Wc_ChaCha20Poly1305_Appended_Tag_Decrypt(inKey, inIv, inAAD, inCipher,  out
 }
 
 func Wc_XChaCha20Poly1305_Encrypt(outCipher, inPlain, inAAD, inIv, inKey []byte) int {
-    if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return BAD_FUNC_ARG }
-    if len(inIv) < XCHACHA20_POLY1305_AEAD_NONCE_SIZE { return BAD_FUNC_ARG }
-    if len(outCipher) < len(inPlain) + CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return BAD_FUNC_ARG }
+    if len(inKey) == 0 || len(inIv) == 0 || len(outCipher) == 0 { return BAD_FUNC_ARG }
     var sanInAAD *C.uchar
     if len(inAAD) > 0 {
         sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
@@ -165,20 +163,21 @@ func Wc_XChaCha20Poly1305_Encrypt(outCipher, inPlain, inAAD, inIv, inKey []byte)
 }
 
 func Wc_XChaCha20Poly1305_Decrypt(outPlain, inCipher, inAAD, inIv, inKey []byte) int {
-    if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return BAD_FUNC_ARG }
-    if len(inIv) < XCHACHA20_POLY1305_AEAD_NONCE_SIZE { return BAD_FUNC_ARG }
-    if len(inCipher) < CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return BAD_FUNC_ARG }
-    if len(outPlain) < len(inCipher) - CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return BAD_FUNC_ARG }
+    if len(inKey) == 0 || len(inIv) == 0 { return BAD_FUNC_ARG }
     var sanInAAD *C.uchar
     if len(inAAD) > 0 {
         sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
+    }
+    var sanInCipher *C.uchar
+    if len(inCipher) > 0 {
+        sanInCipher = (*C.uchar)(unsafe.Pointer(&inCipher[0]))
     }
     var sanOutPlain *C.uchar
     if len(outPlain) > 0 {
         sanOutPlain = (*C.uchar)(unsafe.Pointer(&outPlain[0]))
     }
     return int(C.wc_XChaCha20Poly1305_Decrypt(sanOutPlain, C.size_t(len(outPlain)),
-                (*C.uchar)(unsafe.Pointer(&inCipher[0])), C.size_t(len(inCipher)), sanInAAD, C.size_t(len(inAAD)),
+                sanInCipher, C.size_t(len(inCipher)), sanInAAD, C.size_t(len(inAAD)),
                 (*C.uchar)(unsafe.Pointer(&inIv[0])), C.size_t(len(inIv)),
                 (*C.uchar)(unsafe.Pointer(&inKey[0])), C.size_t(len(inKey))))
 }

--- a/chacha_poly.go
+++ b/chacha_poly.go
@@ -118,13 +118,15 @@ func Wc_ChaCha20Poly1305_Decrypt(inKey, inIv, inAAD, inCipher, inAuthTag , outPl
     var sanInCipher *C.uchar
     if len(inCipher) > 0 {
         sanInCipher = (*C.uchar)(unsafe.Pointer(&inCipher[0]))
-    } else {
-        sanInCipher = (*C.uchar)(unsafe.Pointer(nil))
+    }
+    var sanOutPlain *C.uchar
+    if len(outPlain) > 0 {
+        sanOutPlain = (*C.uchar)(unsafe.Pointer(&outPlain[0]))
     }
 
     return int(C.wc_ChaCha20Poly1305_Decrypt((*C.uchar)(unsafe.Pointer(&inKey[0])), (*C.uchar)(unsafe.Pointer(&inIv[0])),
                sanInAAD, C.word32(len(inAAD)), sanInCipher, C.word32(len(inCipher)),
-               (*C.uchar)(unsafe.Pointer(&inAuthTag[0])), (*C.uchar)(unsafe.Pointer(&outPlain[0]))))
+               (*C.uchar)(unsafe.Pointer(&inAuthTag[0])), sanOutPlain))
 }
 
 func Wc_ChaCha20Poly1305_Appended_Tag_Encrypt(inKey, inIv, inAAD, inPlain, outCipher []byte) ([]byte, int) {
@@ -153,6 +155,9 @@ func Wc_ChaCha20Poly1305_Appended_Tag_Decrypt(inKey, inIv, inAAD, inCipher,  out
 }
 
 func Wc_XChaCha20Poly1305_Encrypt(outCipher, inPlain, inAAD, inIv, inKey []byte) int {
+    if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return BAD_FUNC_ARG }
+    if len(inIv) < XCHACHA20_POLY1305_AEAD_NONCE_SIZE { return BAD_FUNC_ARG }
+    if len(outCipher) == 0 { return BAD_FUNC_ARG }
     var sanInAAD *C.uchar
     if len(inAAD) > 0 {
         sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
@@ -172,6 +177,9 @@ func Wc_XChaCha20Poly1305_Encrypt(outCipher, inPlain, inAAD, inIv, inKey []byte)
 }
 
 func Wc_XChaCha20Poly1305_Decrypt(outPlain, inCipher, inAAD, inIv, inKey []byte) int {
+    if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return BAD_FUNC_ARG }
+    if len(inIv) < XCHACHA20_POLY1305_AEAD_NONCE_SIZE { return BAD_FUNC_ARG }
+    if len(outPlain) == 0 { return BAD_FUNC_ARG }
     var sanInAAD *C.uchar
     if len(inAAD) > 0 {
         sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))

--- a/chacha_poly.go
+++ b/chacha_poly.go
@@ -77,27 +77,21 @@ const XCHACHA20_POLY1305_AEAD_NONCE_SIZE = int(C.XCHACHA20_POLY1305_AEAD_NONCE_S
 const CHACHA20_POLY1305_AEAD_NONCE_SIZE = XCHACHA20_POLY1305_AEAD_NONCE_SIZE/2
 
 func Wc_ChaCha20Poly1305_Encrypt(inKey, inIv, inAAD, inPlain, outCipher, outAuthTag []byte) int {
-    if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return -173 }
-    if len(inIv) < CHACHA20_POLY1305_AEAD_IV_SIZE { return -173 }
-    if len(outAuthTag) < CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return -173 }
-    if len(outCipher) < len(inPlain) { return -173 }
+    if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return BAD_FUNC_ARG }
+    if len(inIv) < CHACHA20_POLY1305_AEAD_IV_SIZE { return BAD_FUNC_ARG }
+    if len(outAuthTag) < CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return BAD_FUNC_ARG }
+    if len(outCipher) < len(inPlain) { return BAD_FUNC_ARG }
     var sanInAAD *C.uchar
     if len(inAAD) > 0 {
         sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
-    } else {
-        sanInAAD = (*C.uchar)(unsafe.Pointer(nil))
     }
     var sanInPlain *C.uchar
     if len(inPlain) > 0 {
         sanInPlain = (*C.uchar)(unsafe.Pointer(&inPlain[0]))
-    } else {
-        sanInPlain = (*C.uchar)(unsafe.Pointer(nil))
     }
     var sanOutCipher *C.uchar
     if len(outCipher) > 0 {
         sanOutCipher = (*C.uchar)(unsafe.Pointer(&outCipher[0]))
-    } else {
-        sanOutCipher = (*C.uchar)(unsafe.Pointer(nil))
     }
     return int(C.wc_ChaCha20Poly1305_Encrypt((*C.uchar)(unsafe.Pointer(&inKey[0])), (*C.uchar)(unsafe.Pointer(&inIv[0])),
                sanInAAD, C.word32(len(inAAD)), sanInPlain, C.word32(len(inPlain)),
@@ -105,15 +99,13 @@ func Wc_ChaCha20Poly1305_Encrypt(inKey, inIv, inAAD, inPlain, outCipher, outAuth
 }
 
 func Wc_ChaCha20Poly1305_Decrypt(inKey, inIv, inAAD, inCipher, inAuthTag , outPlain []byte) int {
-    if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return -173 }
-    if len(inIv) < CHACHA20_POLY1305_AEAD_IV_SIZE { return -173 }
-    if len(inAuthTag) < CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return -173 }
-    if len(outPlain) < len(inCipher) { return -173 }
+    if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return BAD_FUNC_ARG }
+    if len(inIv) < CHACHA20_POLY1305_AEAD_IV_SIZE { return BAD_FUNC_ARG }
+    if len(inAuthTag) < CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return BAD_FUNC_ARG }
+    if len(outPlain) < len(inCipher) { return BAD_FUNC_ARG }
     var sanInAAD *C.uchar
     if len(inAAD) > 0 {
         sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
-    } else {
-        sanInAAD = (*C.uchar)(unsafe.Pointer(nil))
     }
     var sanInCipher *C.uchar
     if len(inCipher) > 0 {
@@ -157,18 +149,14 @@ func Wc_ChaCha20Poly1305_Appended_Tag_Decrypt(inKey, inIv, inAAD, inCipher,  out
 func Wc_XChaCha20Poly1305_Encrypt(outCipher, inPlain, inAAD, inIv, inKey []byte) int {
     if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return BAD_FUNC_ARG }
     if len(inIv) < XCHACHA20_POLY1305_AEAD_NONCE_SIZE { return BAD_FUNC_ARG }
-    if len(outCipher) == 0 { return BAD_FUNC_ARG }
+    if len(outCipher) < len(inPlain) + CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return BAD_FUNC_ARG }
     var sanInAAD *C.uchar
     if len(inAAD) > 0 {
         sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
-    } else {
-        sanInAAD = (*C.uchar)(unsafe.Pointer(nil))
     }
     var sanInPlain *C.uchar
     if len(inPlain) > 0 {
         sanInPlain = (*C.uchar)(unsafe.Pointer(&inPlain[0]))
-    } else {
-        sanInPlain = (*C.uchar)(unsafe.Pointer(nil))
     }
     return int(C.wc_XChaCha20Poly1305_Encrypt((*C.uchar)(unsafe.Pointer(&outCipher[0])), C.size_t(len(outCipher)),
                 sanInPlain, C.size_t(len(inPlain)), sanInAAD, C.size_t(len(inAAD)),
@@ -179,21 +167,18 @@ func Wc_XChaCha20Poly1305_Encrypt(outCipher, inPlain, inAAD, inIv, inKey []byte)
 func Wc_XChaCha20Poly1305_Decrypt(outPlain, inCipher, inAAD, inIv, inKey []byte) int {
     if len(inKey) < CHACHA20_POLY1305_AEAD_KEYSIZE { return BAD_FUNC_ARG }
     if len(inIv) < XCHACHA20_POLY1305_AEAD_NONCE_SIZE { return BAD_FUNC_ARG }
-    if len(outPlain) == 0 { return BAD_FUNC_ARG }
+    if len(inCipher) < CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return BAD_FUNC_ARG }
+    if len(outPlain) < len(inCipher) - CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE { return BAD_FUNC_ARG }
     var sanInAAD *C.uchar
     if len(inAAD) > 0 {
         sanInAAD = (*C.uchar)(unsafe.Pointer(&inAAD[0]))
-    } else {
-        sanInAAD = (*C.uchar)(unsafe.Pointer(nil))
     }
-    var sanInCipher *C.uchar
-    if len(inCipher) > 0 {
-        sanInCipher = (*C.uchar)(unsafe.Pointer(&inCipher[0]))
-    } else {
-        sanInCipher = (*C.uchar)(unsafe.Pointer(nil))
+    var sanOutPlain *C.uchar
+    if len(outPlain) > 0 {
+        sanOutPlain = (*C.uchar)(unsafe.Pointer(&outPlain[0]))
     }
-    return int(C.wc_XChaCha20Poly1305_Decrypt((*C.uchar)(unsafe.Pointer(&outPlain[0])), C.size_t(len(outPlain)),
-                sanInCipher, C.size_t(len(inCipher)), sanInAAD, C.size_t(len(inAAD)),
+    return int(C.wc_XChaCha20Poly1305_Decrypt(sanOutPlain, C.size_t(len(outPlain)),
+                (*C.uchar)(unsafe.Pointer(&inCipher[0])), C.size_t(len(inCipher)), sanInAAD, C.size_t(len(inAAD)),
                 (*C.uchar)(unsafe.Pointer(&inIv[0])), C.size_t(len(inIv)),
                 (*C.uchar)(unsafe.Pointer(&inKey[0])), C.size_t(len(inKey))))
 }

--- a/curve25519.go
+++ b/curve25519.go
@@ -85,11 +85,13 @@ func Wc_curve25519_make_key(rng *C.struct_WC_RNG, keySize int, key *C.struct_cur
 }
 
 func Wc_curve25519_make_pub(pub, priv []byte) int {
+    if len(pub) == 0 || len(priv) == 0 { return BAD_FUNC_ARG }
     return int(C.wc_curve25519_make_pub(C.int(len(pub)),(*C.uchar)(unsafe.Pointer(&pub[0])),
                C.int(len(priv)), (*C.uchar)(unsafe.Pointer(&priv[0]))))
 }
 
 func Wc_curve25519_make_priv(rng *C.struct_WC_RNG, priv []byte) int {
+    if len(priv) == 0 { return BAD_FUNC_ARG }
     return int(C.wc_curve25519_make_priv(rng,
                C.int(len(priv)), (*C.uchar)(unsafe.Pointer(&priv[0]))))
 }

--- a/ecc.go
+++ b/ecc.go
@@ -30,6 +30,7 @@ package wolfSSL
 // #define ECC_MAX_SIG_SIZE 1
 // #define ECC_SECP256R1 1
 // typedef struct ecc_key {} ecc_key;
+// typedef struct ecc_point {} ecc_point;
 // int wc_ecc_init(ecc_key *key) {
 //      return -174;
 //  }

--- a/ecc.go
+++ b/ecc.go
@@ -28,6 +28,7 @@ package wolfSSL
 // #include <wolfssl/wolfcrypt/random.h>
 // #ifndef HAVE_ECC
 // #define ECC_MAX_SIG_SIZE 1
+// #define ECC_SECP256R1 1
 // typedef struct ecc_key {} ecc_key;
 // int wc_ecc_init(ecc_key *key) {
 //      return -174;
@@ -36,6 +37,28 @@ package wolfSSL
 //      return -174;
 //  }
 // int wc_ecc_make_key(WC_RNG* rng, int keysize, ecc_key* key) {
+//      return -174;
+//  }
+// int wc_ecc_make_pub(ecc_key* key, ecc_point* pubOut) {
+//      return -174;
+//  }
+// int wc_ecc_set_rng(ecc_key* key, WC_RNG* rng) {
+//      return -174;
+//  }
+// int wc_ecc_export_private_only(ecc_key* key, byte* out, word32* outLen) {
+//      return -174;
+//  }
+// int wc_ecc_export_x963_ex(ecc_key* key, byte* out, word32* outLen,
+//                           int compressed) {
+//      return -174;
+//  }
+// int wc_ecc_import_private_key_ex(const byte* priv, word32 privSz,
+//                                  const byte* pub, word32 pubSz,
+//                                  ecc_key* key, int curve_id) {
+//      return -174;
+//  }
+// int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
+//                           int curve_id) {
 //      return -174;
 //  }
 // int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
@@ -48,6 +71,13 @@ package wolfSSL
 //  }
 // int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
 //                        ecc_key* key, word32 inSz) {
+//      return -174;
+//  }
+// int wc_ecc_check_key(ecc_key* key) {
+//      return -174;
+//  }
+// int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key,
+//                          byte* out, word32* outlen) {
 //      return -174;
 //  }
 // #endif

--- a/examples/aes-encrypt/aes-encrypt.go
+++ b/examples/aes-encrypt/aes-encrypt.go
@@ -123,13 +123,14 @@ func AesEncrypt(aes wolfSSL.Aes, inFile string, outFile string, size int) {
         salt[0] = 1
     }
 
-    ret = wolfSSL.Wc_PBKDF2(key, key, len(key), salt, SALT_SIZE, 4096, size, wolfSSL.WC_SHA256)
+    derivedKey := make([]byte, size)
+    ret = wolfSSL.Wc_PBKDF2(derivedKey, key, len(key), salt, SALT_SIZE, 4096, size, wolfSSL.WC_SHA256)
     if ret != 0 {
         fmt.Println("Failed to stretch key")
         os.Exit(1)
     }
 
-    ret = wolfSSL.Wc_AesSetKey(&aes, key, size, iv, wolfSSL.AES_ENCRYPTION)
+    ret = wolfSSL.Wc_AesSetKey(&aes, derivedKey, size, iv, wolfSSL.AES_ENCRYPTION)
     if ret != 0 {
         fmt.Println("Failed to set AES key", ret)
         os.Exit(1)
@@ -211,13 +212,14 @@ func AesDecrypt(aes wolfSSL.Aes, inFile string, outFile string, size int) {
         os.Exit(1)
     }
 
-    ret = wolfSSL.Wc_PBKDF2(key, key, len(key), salt, SALT_SIZE, 4096, size, wolfSSL.WC_SHA256)
+    derivedKey := make([]byte, size)
+    ret = wolfSSL.Wc_PBKDF2(derivedKey, key, len(key), salt, SALT_SIZE, 4096, size, wolfSSL.WC_SHA256)
     if ret != 0 {
         fmt.Println("Failed to stretch key")
         os.Exit(1)
     }
 
-    ret = wolfSSL.Wc_AesSetKey(&aes, key, size, iv, wolfSSL.AES_DECRYPTION)
+    ret = wolfSSL.Wc_AesSetKey(&aes, derivedKey, size, iv, wolfSSL.AES_DECRYPTION)
     if ret != 0 {
         fmt.Println("Failed to set AES key", ret)
         os.Exit(1)

--- a/examples/aes-encrypt/aes-encrypt.go
+++ b/examples/aes-encrypt/aes-encrypt.go
@@ -61,7 +61,7 @@ func getPass() []byte {
     return pass
 }
 
-func AesEncrypt(aes wolfSSL.Aes, inFile string, outFile string, size int) {
+func AesEncrypt(aes *wolfSSL.Aes, inFile string, outFile string, size int) {
     var rng    wolfSSL.WC_RNG
     var input  []byte
     var output []byte
@@ -130,13 +130,13 @@ func AesEncrypt(aes wolfSSL.Aes, inFile string, outFile string, size int) {
         os.Exit(1)
     }
 
-    ret = wolfSSL.Wc_AesSetKey(&aes, derivedKey, size, iv, wolfSSL.AES_ENCRYPTION)
+    ret = wolfSSL.Wc_AesSetKey(aes, derivedKey, size, iv, wolfSSL.AES_ENCRYPTION)
     if ret != 0 {
         fmt.Println("Failed to set AES key", ret)
         os.Exit(1)
     }
 
-    ret = wolfSSL.Wc_AesCbcEncrypt(&aes, output, input, length)
+    ret = wolfSSL.Wc_AesCbcEncrypt(aes, output, input, length)
     if ret != 0 {
         fmt.Println("Failed AES encrypt")
         os.Exit(1)
@@ -172,7 +172,7 @@ func AesEncrypt(aes wolfSSL.Aes, inFile string, outFile string, size int) {
     }
 }
 
-func AesDecrypt(aes wolfSSL.Aes, inFile string, outFile string, size int) {
+func AesDecrypt(aes *wolfSSL.Aes, inFile string, outFile string, size int) {
     var rng    wolfSSL.WC_RNG
     var output []byte
     var iv     []byte = make([]byte, wolfSSL.AES_BLOCK_SIZE)
@@ -219,7 +219,7 @@ func AesDecrypt(aes wolfSSL.Aes, inFile string, outFile string, size int) {
         os.Exit(1)
     }
 
-    ret = wolfSSL.Wc_AesSetKey(&aes, derivedKey, size, iv, wolfSSL.AES_DECRYPTION)
+    ret = wolfSSL.Wc_AesSetKey(aes, derivedKey, size, iv, wolfSSL.AES_DECRYPTION)
     if ret != 0 {
         fmt.Println("Failed to set AES key", ret)
         os.Exit(1)
@@ -233,7 +233,7 @@ func AesDecrypt(aes wolfSSL.Aes, inFile string, outFile string, size int) {
         i++
     }
 
-    ret = wolfSSL.Wc_AesCbcDecrypt(&aes, output, input, length)
+    ret = wolfSSL.Wc_AesCbcDecrypt(aes, output, input, length)
     if ret != 0 {
         fmt.Println("Failed AES encrypt",ret)
         os.Exit(1)
@@ -302,15 +302,14 @@ func main() {
     sizeCheck(&size)
 
     wolfSSL.Wc_AesInit(aes, nil, wolfSSL.INVALID_DEVID)
+    defer wolfSSL.Wc_AesFree(aes)
 
     if operation == "enc" {
-        AesEncrypt(*aes, inFile, outFile, size)
+        AesEncrypt(aes, inFile, outFile, size)
     } else if operation == "dec" {
-        AesDecrypt(*aes, inFile, outFile, size)
+        AesDecrypt(aes, inFile, outFile, size)
     } else {
         fmt.Println("Invalid operation. Please use enc or dec.");
         fmt.Println("Usage: ./aesEncrypt <infile name> <outfile name> <enc/dec> <key size>");
     }
-
-    wolfSSL.Wc_AesFree(aes)
 }

--- a/examples/aes-encrypt/aes-encrypt.go
+++ b/examples/aes-encrypt/aes-encrypt.go
@@ -191,6 +191,11 @@ func AesDecrypt(aes *wolfSSL.Aes, inFile string, outFile string, size int) {
     inputLength = len(input)
     length = inputLength
 
+    if length < wolfSSL.AES_BLOCK_SIZE + SALT_SIZE {
+        fmt.Println("File too short or corrupted")
+        os.Exit(1)
+    }
+
     output = make([]byte, length)
 
     key := getPass()
@@ -240,7 +245,7 @@ func AesDecrypt(aes *wolfSSL.Aes, inFile string, outFile string, size int) {
     }
 
     if salt[0] != 0 {
-        if length == 0 {
+        if length < wolfSSL.AES_BLOCK_SIZE {
             fmt.Println("File too short or corrupted")
             os.Exit(1)
         }

--- a/examples/client/client-dtls.go
+++ b/examples/client/client-dtls.go
@@ -116,7 +116,7 @@ func main() {
     /* Recieve then print the message from server */
     buf := make([]byte, 256)
     ret = wolfSSL.WolfSSL_read(ssl, buf, 256)
-    if ret == -1 {
+    if ret < 0 {
         fmt.Println(" wolfSSL_read failed ");
     } else {
         fmt.Println("Server says : ", string(buf));

--- a/examples/client/client-psk.go
+++ b/examples/client/client-psk.go
@@ -120,7 +120,7 @@ func main() {
     /* Recieve then print the message from server */
     buf := make([]byte, 256)
     ret = wolfSSL.WolfSSL_read(ssl, buf, 256)
-    if ret == -1 {
+    if ret < 0 {
         fmt.Println(" wolfSSL_read failed ");
     } else {
         fmt.Println("Server says : ", string(buf));

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -105,7 +105,7 @@ func main() {
     /* Recieve then print the message from server */
     buf := make([]byte, 256)
     ret = wolfSSL.WolfSSL_read(ssl, buf, 256)
-    if ret == -1 {
+    if ret < 0 {
         fmt.Println(" wolfSSL_read failed ");
     } else {
         fmt.Println("Server says : ", string(buf));

--- a/examples/ecc-sign-verify/ecc-sign-verify.go
+++ b/examples/ecc-sign-verify/ecc-sign-verify.go
@@ -50,6 +50,7 @@ func sign_verify(eccKeySz int, hash []byte, printSig int) {
         fmt.Println("Failed to initialize ecc_key")
         os.Exit(1)
     }
+    defer wolfSSL.Wc_ecc_free(&key)
 
     /* Initialize rng */
     ret = wolfSSL.Wc_InitRng(&rng)
@@ -57,6 +58,7 @@ func sign_verify(eccKeySz int, hash []byte, printSig int) {
         fmt.Println("Failed to initialize rng")
         os.Exit(1)
     }
+    defer wolfSSL.Wc_FreeRng(&rng)
 
     /* Make ecc key with calculated byteField */
     ret = wolfSSL.Wc_ecc_make_key(&rng, byteField, &key)

--- a/examples/server/server-dtls.go
+++ b/examples/server/server-dtls.go
@@ -76,11 +76,17 @@ func main() {
     fmt.Println("Listening on " + CONN_HOST + ":" + CONN_PORT)
     buffer := make([]byte, 5)
     _, addr, err := conn.ReadFromUDP(buffer)
+    if err != nil {
+        fmt.Println("Error reading from UDP: ", err.Error())
+        os.Exit(1)
+    }
     /* Listen for an incoming connection */
     c , err := net.DialUDP(CONN_TYPE, nil, addr)
     if err != nil {
         fmt.Println("Error accepting: ", err.Error())
+        os.Exit(1)
     }
+    defer c.Close()
 
     /* Create a WOLFSSL object */
     ssl := wolfSSL.WolfSSL_new(ctx)
@@ -91,6 +97,11 @@ func main() {
 
     /* Retrieve file descriptor from connected socket */
     file,err := c.File()
+    if err != nil {
+        fmt.Println("Error getting file descriptor: ", err.Error())
+        os.Exit(1)
+    }
+    defer file.Close()
     fd := file.Fd()
     wolfSSL.WolfSSL_set_fd(ssl, int(fd))
 
@@ -110,7 +121,7 @@ func main() {
 
     /* Recieve then print the message from client */
     ret = wolfSSL.WolfSSL_read(ssl, buf, 256)
-    if ret == -1 {
+    if ret < 0 {
         fmt.Println(" WolfSSL_read failed ");
     } else {
         fmt.Println("Client says : ", string(buf));

--- a/examples/server/server-dtls.go
+++ b/examples/server/server-dtls.go
@@ -89,8 +89,8 @@ func main() {
         os.Exit(1)
     }
 
-    /* Retrieve file descriptor from net.Conn type */
-    file,err := conn.File()//(*net.Conn).File()
+    /* Retrieve file descriptor from connected socket */
+    file,err := c.File()
     fd := file.Fd()
     wolfSSL.WolfSSL_set_fd(ssl, int(fd))
 

--- a/examples/server/server-psk.go
+++ b/examples/server/server-psk.go
@@ -118,7 +118,7 @@ func main() {
 
     /* Recieve then print the message from client */
     ret = wolfSSL.WolfSSL_read(ssl, buf, 256)
-    if ret == -1 {
+    if ret < 0 {
         fmt.Println(" WolfSSL_read failed ");
     } else {
         fmt.Println("Client says : ", string(buf));

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -105,7 +105,7 @@ func main() {
 
     /* Recieve then print the message from client */
     ret = wolfSSL.WolfSSL_read(ssl, buf, 256)
-    if ret == -1 {
+    if ret < 0 {
         fmt.Println(" WolfSSL_read failed ");
     } else {
         fmt.Println("Client says : ", string(buf));

--- a/generateOptions.sh
+++ b/generateOptions.sh
@@ -11,7 +11,7 @@
 OPTIONS_H="../wolfssl/wolfssl/options.h"
 PREFIX=""
 
-if [ ! -z "$1" ]; then
+if [ -n "$1" ]; then
     WOLFSSL_PATH="$1"
     echo "Path to wolfSSL was supplied."
 
@@ -37,7 +37,7 @@ echo "package wolfSSL" >> options.go
 echo ""                >> options.go
 echo "// #cgo CFLAGS: -g -Wall -I/usr/include -I/usr/include/wolfssl" >> options.go
 echo "// #cgo LDFLAGS: -L/usr/local/lib -lwolfssl -lm"                >> options.go
-sed 's/^/\/\/ /' $OPTIONS_H                                           >> options.go
+sed 's/^/\/\/ /' "$OPTIONS_H"                                          >> options.go
 echo "options.go generated."
 
 # When the supplied path is an installed wolfSSL prefix, repoint cgo

--- a/hmac.go
+++ b/hmac.go
@@ -105,6 +105,9 @@ func Wc_HKDF(hashType int, inputKey []byte, inputKeySz int, salt []byte,
     if infoSz < 0 || infoSz > len(info) { return BAD_FUNC_ARG }
     if outSz < 0 || outSz > len(out) { return BAD_FUNC_ARG }
     if len(out) == 0 { return BAD_FUNC_ARG }
+    // RFC 5869 permits a zero-length IKM (the Noise protocol's final
+    // Split() step relies on this, passing ck as salt and "" as IKM).
+    // Pass a NULL pointer to wolfCrypt rather than indexing an empty slice.
     var ikmPtr *C.uchar
     if len(inputKey) > 0 {
         ikmPtr = (*C.uchar)(unsafe.Pointer(&inputKey[0]))

--- a/sha.go
+++ b/sha.go
@@ -23,6 +23,21 @@ package wolfSSL
 
 // #include <wolfssl/options.h>
 // #include <wolfssl/wolfcrypt/sha256.h>
+// #ifdef NO_SHA256
+// typedef struct wc_Sha256 {} wc_Sha256;
+// int wc_InitSha256_ex(wc_Sha256* sha, void* heap, int devId) {
+//      return -174;
+// }
+// void wc_Sha256Free(wc_Sha256* sha) {
+//      return;
+// }
+// int wc_Sha256Update(wc_Sha256* sha, const byte* data, word32 len) {
+//      return -174;
+// }
+// int wc_Sha256Final(wc_Sha256* sha, byte* hash) {
+//      return -174;
+// }
+// #endif
 import "C"
 import (
     "unsafe"

--- a/sha.go
+++ b/sha.go
@@ -71,6 +71,6 @@ func Wc_Sha256Copy(src *C.struct_wc_Sha256, dst *C.struct_wc_Sha256) int {
 }
 
 func Wc_Sha256Final(sha *C.struct_wc_Sha256, out []byte) int {
-    if len(out) < WC_SHA256_DIGEST_SIZE { return -173 }
+    if len(out) < WC_SHA256_DIGEST_SIZE { return BAD_FUNC_ARG }
     return int(C.wc_Sha256Final(sha, (*C.uchar)(unsafe.Pointer(&out[0]))))
 }

--- a/ssl.go
+++ b/ssl.go
@@ -264,17 +264,14 @@ func WolfSSL_accept(ssl *C.struct_WOLFSSL) int {
 }
 
 func WolfSSL_read(ssl *C.struct_WOLFSSL, data []byte, sz uintptr) int {
-    // Return BAD_FUNC_ARG on invalid input so callers do not mistake it
-    // for a clean peer close (which SSL_read signals with 0).
-    if sz == 0 || len(data) == 0 || sz > uintptr(len(data)) {
+    if sz == 0 { return 0 }
+    if len(data) == 0 || sz > uintptr(len(data)) {
         return BAD_FUNC_ARG
     }
     return int(C.wolfSSL_read(ssl, unsafe.Pointer(&data[0]), C.int(sz)))
 }
 
 func WolfSSL_write(ssl *C.struct_WOLFSSL, data []byte, sz uintptr) int {
-    // Zero-length write is a legitimate no-op; return 0 to match standard
-    // I/O conventions. Oversized sz is still invalid.
     if sz == 0 { return 0 }
     if len(data) == 0 || sz > uintptr(len(data)) {
         return BAD_FUNC_ARG

--- a/ssl.go
+++ b/ssl.go
@@ -264,18 +264,21 @@ func WolfSSL_accept(ssl *C.struct_WOLFSSL) int {
 }
 
 func WolfSSL_read(ssl *C.struct_WOLFSSL, data []byte, sz uintptr) int {
-    if sz > uintptr(len(data)) {
-        sz = uintptr(len(data))
+    // Return BAD_FUNC_ARG on invalid input so callers do not mistake it
+    // for a clean peer close (which SSL_read signals with 0).
+    if sz == 0 || len(data) == 0 || sz > uintptr(len(data)) {
+        return BAD_FUNC_ARG
     }
-    if sz == 0 { return 0 }
     return int(C.wolfSSL_read(ssl, unsafe.Pointer(&data[0]), C.int(sz)))
 }
 
 func WolfSSL_write(ssl *C.struct_WOLFSSL, data []byte, sz uintptr) int {
-    if sz > uintptr(len(data)) {
-        sz = uintptr(len(data))
-    }
+    // Zero-length write is a legitimate no-op; return 0 to match standard
+    // I/O conventions. Oversized sz is still invalid.
     if sz == 0 { return 0 }
+    if len(data) == 0 || sz > uintptr(len(data)) {
+        return BAD_FUNC_ARG
+    }
     return int(C.wolfSSL_write(ssl, unsafe.Pointer(&data[0]), C.int(sz)))
 }
 

--- a/x509.go
+++ b/x509.go
@@ -291,6 +291,7 @@ func WolfSSL_d2i_ASN1_OBJECT(a **WOLFSSL_ASN1_OBJECT, der *[]byte, length int) *
 	if a != nil {
 		aPtr = (**C.struct_WOLFSSL_ASN1_OBJECT)(unsafe.Pointer(a))
 	}
+
 	cBuf := C.CBytes(*der)
 	defer C.free(cBuf)
 	cStart := (*C.uchar)(cBuf)

--- a/x509.go
+++ b/x509.go
@@ -256,21 +256,22 @@ func WolfSSL_ASN1_get_object(in *[]byte, objLen *int, tag *int, cls *int, inLen 
 		return -1
 	}
 
-	cInPtr := (*C.uchar)(C.malloc(C.size_t(unsafe.Sizeof(uintptr(0)))))
-	defer C.free(unsafe.Pointer(cInPtr))
-
-	inPtr := (*C.uchar)(unsafe.Pointer(&(*in)[0]))
-	*(**C.uchar)(unsafe.Pointer(cInPtr)) = inPtr
+	// Copy the input to C memory so the pointer-to-pointer indirection
+	// never holds a Go pointer (cgo rule: Go memory passed to C must not
+	// contain Go pointers).
+	cBuf := C.CBytes(*in)
+	defer C.free(cBuf)
+	cStart := (*C.uchar)(cBuf)
+	cInPtr := cStart
 
 	var cLen C.long
 	var cTag C.int
 	var cCls C.int
 
-	result := int(C.wolfSSL_ASN1_get_object((**C.uchar)(unsafe.Pointer(cInPtr)), &cLen, &cTag, &cCls, C.long(inLen)))
+	result := int(C.wolfSSL_ASN1_get_object(&cInPtr, &cLen, &cTag, &cCls, C.long(inLen)))
 
 	if result >= 0 {
-		newPtr := *(**C.uchar)(unsafe.Pointer(cInPtr))
-		offset := uintptr(unsafe.Pointer(newPtr)) - uintptr(unsafe.Pointer(&(*in)[0]))
+		offset := uintptr(unsafe.Pointer(cInPtr)) - uintptr(unsafe.Pointer(cStart))
 		if offset > uintptr(len(*in)) { return -1 }
 		*in = (*in)[offset:]
 		*objLen = int(cLen)
@@ -290,18 +291,15 @@ func WolfSSL_d2i_ASN1_OBJECT(a **WOLFSSL_ASN1_OBJECT, der *[]byte, length int) *
 	if a != nil {
 		aPtr = (**C.struct_WOLFSSL_ASN1_OBJECT)(unsafe.Pointer(a))
 	}
+	cBuf := C.CBytes(*der)
+	defer C.free(cBuf)
+	cStart := (*C.uchar)(cBuf)
+	cDerPtr := cStart
 
-	cDerPtr := (*C.uchar)(C.malloc(C.size_t(unsafe.Sizeof(uintptr(0)))))
-	defer C.free(unsafe.Pointer(cDerPtr))
-
-	derPtr := (*C.uchar)(unsafe.Pointer(&(*der)[0]))
-	*(**C.uchar)(unsafe.Pointer(cDerPtr)) = derPtr
-
-	result := (*WOLFSSL_ASN1_OBJECT)(C.wolfSSL_d2i_ASN1_OBJECT(aPtr, (**C.uchar)(unsafe.Pointer(cDerPtr)), C.long(length)))
+	result := (*WOLFSSL_ASN1_OBJECT)(C.wolfSSL_d2i_ASN1_OBJECT(aPtr, &cDerPtr, C.long(length)))
 
 	if result != nil {
-		newPtr := *(**C.uchar)(unsafe.Pointer(cDerPtr))
-		offset := uintptr(unsafe.Pointer(newPtr)) - uintptr(unsafe.Pointer(&(*der)[0]))
+		offset := uintptr(unsafe.Pointer(cDerPtr)) - uintptr(unsafe.Pointer(cStart))
 		if offset > uintptr(len(*der)) { return nil }
 		*der = (*der)[offset:]
 	}


### PR DESCRIPTION
Fixes F-1414, F-1415, F-1416, F-1417, F-1418, F-1419, F-1410, F-1411, F-1420, F-1421, F-1422, F-1412, F-1413, F-1780                                                                    
                                                                                               
  - Fix unused variable compile error in DTLS server example                                   
  - Separate PBKDF2 output buffer from password input in AES example                           
  - Pass Aes struct by pointer and use aligned allocator in AES example                        
  - Free ECC key and RNG resources in ECC sign/verify example                                  
  - Add empty slice guards to curve25519 make_pub/make_priv
  - Validate key, IV, nonce sizes in XChaCha20Poly1305 encrypt/decrypt                         
  - Replace C.malloc pointer indirection with Go-allocated variable in ASN1 functions          
  - Add missing ECC preamble stubs for !HAVE_ECC builds                                        
  - Nil-sanitize outPlain in ChaCha20Poly1305 Decrypt                                          
  - Add NO_SHA256 preamble stubs for streaming SHA-256 API                                     
  - Quote shell variable expansions in generateOptions.sh  