### PR TITLE
Fix arg checking bug in Wc_HmacFinal

### DIFF
--- a/hmac.go
+++ b/hmac.go
@@ -94,7 +94,7 @@ func Wc_HmacUpdate(hmac *C.struct_Hmac, in []byte, inSz int) int {
 }
 
 func Wc_HmacFinal(hmac *C.struct_Hmac, out []byte) int {
-    if len(out) < int(C.WC_MAX_DIGEST_SIZE) { return BAD_FUNC_ARG }
+    if len(out) == 0 { return BAD_FUNC_ARG } 
     return int(C.wc_HmacFinal(hmac, (*C.uchar)(unsafe.Pointer(&out[0]))))
 }
 


### PR DESCRIPTION
Wc_HmacFinal checks that out is at least WC_MAX_DIGEST_SIZE (64 bytes for SHA-512), but callers pass 32-byte SHA-256 buffers. The C function wc_HmacFinal only writes the digest size for the configured hash type, so the check is too strict.