### PR TITLE
Add an AesGcmAEAD wrapper for crypto/cipher.AEAD compatability

### DIFF
--- a/aes.go
+++ b/aes.go
@@ -118,6 +118,7 @@ package wolfSSL
 // #endif
 import "C"
 import (
+    "fmt"
     "unsafe"
 )
 
@@ -274,4 +275,64 @@ func Wc_PBKDF2(out []byte, pwd []byte, pLen int, salt []byte, saltLen int, iter 
     }
     return int(C.wc_PBKDF2(outPtr, pwdPtr, C.int(pLen),
                saltPtr, C.int(saltLen), C.int(iter), C.int(kLen), C.int(typeH)))
+}
+
+// AesGcmAEAD implements crypto/cipher.AEAD using wolfCrypt AES-256-GCM.
+// Create one with NewAesGcmAEAD.
+type AesGcmAEAD struct {
+    key [AES_256_KEY_SIZE]byte
+}
+
+// NewAesGcmAEAD returns an AesGcmAEAD keyed with a 32-byte AES-256 key.
+func NewAesGcmAEAD(key [AES_256_KEY_SIZE]byte) *AesGcmAEAD {
+    return &AesGcmAEAD{key: key}
+}
+
+func (a *AesGcmAEAD) NonceSize() int { return AES_IV_SIZE }
+func (a *AesGcmAEAD) Overhead() int  { return AES_BLOCK_SIZE }
+
+// Seal encrypts and authenticates plaintext, appending the result to dst.
+// The ciphertext and tag are concatenated: dst || ct || tag.
+func (a *AesGcmAEAD) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
+    aes := Wc_AesAllocAligned()
+    Wc_AesInit(aes, nil, INVALID_DEVID)
+    Wc_AesGcmSetKey(aes, a.key[:], AES_256_KEY_SIZE)
+    defer func() {
+        Wc_AesFree(aes)
+        Wc_AesFreeAllocAligned(aes)
+    }()
+
+    ct := make([]byte, len(plaintext))
+    var tag [AES_BLOCK_SIZE]byte
+    Wc_AesGcmEncrypt(aes, ct, plaintext, nonce, tag[:], additionalData)
+
+    ret := append(dst, ct...)
+    ret = append(ret, tag[:]...)
+    return ret
+}
+
+// Open decrypts and verifies ciphertext (which must include the appended
+// tag), appending the plaintext to dst.
+func (a *AesGcmAEAD) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
+    if len(ciphertext) < AES_BLOCK_SIZE {
+        return nil, fmt.Errorf("wolfSSL: ciphertext too short (%d bytes)", len(ciphertext))
+    }
+    aes := Wc_AesAllocAligned()
+    Wc_AesInit(aes, nil, INVALID_DEVID)
+    Wc_AesGcmSetKey(aes, a.key[:], AES_256_KEY_SIZE)
+    defer func() {
+        Wc_AesFree(aes)
+        Wc_AesFreeAllocAligned(aes)
+    }()
+
+    ctLen := len(ciphertext) - AES_BLOCK_SIZE
+    ct := ciphertext[:ctLen]
+    tag := ciphertext[ctLen:]
+
+    plaintext := make([]byte, ctLen)
+    ret := Wc_AesGcmDecrypt(aes, plaintext, ct, nonce, tag, additionalData)
+    if ret != 0 {
+        return nil, fmt.Errorf("wolfSSL: AES-GCM decrypt failed: %d", ret)
+    }
+    return append(dst, plaintext...), nil
 }

--- a/aes.go
+++ b/aes.go
@@ -118,6 +118,7 @@ package wolfSSL
 // #endif
 import "C"
 import (
+    "errors"
     "fmt"
     "unsafe"
 )
@@ -291,48 +292,80 @@ func NewAesGcmAEAD(key [AES_256_KEY_SIZE]byte) *AesGcmAEAD {
 func (a *AesGcmAEAD) NonceSize() int { return AES_IV_SIZE }
 func (a *AesGcmAEAD) Overhead() int  { return AES_BLOCK_SIZE }
 
+// Error so callers can't distinguish short ciphertext from a bad tag or wrong AAD.
+var errAEADOpen = errors.New("message authentication failed")
+
+// newAesGcm allocates, initializes, and keys an AES-GCM context using the
+// AEAD's key. The returned context must be released with freeAesGcm.
+func (a *AesGcmAEAD) newAesGcm() (*C.struct_Aes, error) {
+    aes := Wc_AesAllocAligned()
+    if aes == nil {
+        return nil, errors.New("wolfSSL: AES allocation failed")
+    }
+    if ret := Wc_AesInit(aes, nil, INVALID_DEVID); ret != 0 {
+        Wc_AesFreeAllocAligned(aes)
+        return nil, fmt.Errorf("wolfSSL: AES init failed: %d", ret)
+    }
+    if ret := Wc_AesGcmSetKey(aes, a.key[:], AES_256_KEY_SIZE); ret != 0 {
+        Wc_AesFree(aes)
+        Wc_AesFreeAllocAligned(aes)
+        return nil, fmt.Errorf("wolfSSL: AES-GCM set key failed: %d", ret)
+    }
+    return aes, nil
+}
+
+func (a *AesGcmAEAD) freeAesGcm(aes *C.struct_Aes) {
+    Wc_AesFree(aes)
+    Wc_AesFreeAllocAligned(aes)
+}
+
 // Seal encrypts and authenticates plaintext, appending the result to dst.
 // The ciphertext and tag are concatenated: dst || ct || tag.
 func (a *AesGcmAEAD) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
-    aes := Wc_AesAllocAligned()
-    Wc_AesInit(aes, nil, INVALID_DEVID)
-    Wc_AesGcmSetKey(aes, a.key[:], AES_256_KEY_SIZE)
-    defer func() {
-        Wc_AesFree(aes)
-        Wc_AesFreeAllocAligned(aes)
-    }()
+    if len(nonce) != a.NonceSize() {
+        panic("incorrect nonce length given to GCM")
+    }
+
+    aes, err := a.newAesGcm()
+    if err != nil {
+        panic(err.Error())
+    }
+    defer a.freeAesGcm(aes)
 
     ct := make([]byte, len(plaintext))
     var tag [AES_BLOCK_SIZE]byte
-    Wc_AesGcmEncrypt(aes, ct, plaintext, nonce, tag[:], additionalData)
+    if ret := Wc_AesGcmEncrypt(aes, ct, plaintext, nonce, tag[:], additionalData); ret != 0 {
+        panic(fmt.Sprintf("wolfSSL: AES-GCM encrypt failed: %d", ret))
+    }
 
-    ret := append(dst, ct...)
-    ret = append(ret, tag[:]...)
-    return ret
+    out := append(dst, ct...)
+    out = append(out, tag[:]...)
+    return out
 }
 
 // Open decrypts and verifies ciphertext (which must include the appended
 // tag), appending the plaintext to dst.
 func (a *AesGcmAEAD) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
-    if len(ciphertext) < AES_BLOCK_SIZE {
-        return nil, fmt.Errorf("wolfSSL: ciphertext too short (%d bytes)", len(ciphertext))
+    if len(nonce) != a.NonceSize() {
+        panic("incorrect nonce length given to GCM")
     }
-    aes := Wc_AesAllocAligned()
-    Wc_AesInit(aes, nil, INVALID_DEVID)
-    Wc_AesGcmSetKey(aes, a.key[:], AES_256_KEY_SIZE)
-    defer func() {
-        Wc_AesFree(aes)
-        Wc_AesFreeAllocAligned(aes)
-    }()
+    if len(ciphertext) < AES_BLOCK_SIZE {
+        return nil, errAEADOpen
+    }
+
+    aes, err := a.newAesGcm()
+    if err != nil {
+        return nil, err
+    }
+    defer a.freeAesGcm(aes)
 
     ctLen := len(ciphertext) - AES_BLOCK_SIZE
     ct := ciphertext[:ctLen]
     tag := ciphertext[ctLen:]
 
     plaintext := make([]byte, ctLen)
-    ret := Wc_AesGcmDecrypt(aes, plaintext, ct, nonce, tag, additionalData)
-    if ret != 0 {
-        return nil, fmt.Errorf("wolfSSL: AES-GCM decrypt failed: %d", ret)
+    if ret := Wc_AesGcmDecrypt(aes, plaintext, ct, nonce, tag, additionalData); ret != 0 {
+        return nil, errAEADOpen
     }
     return append(dst, plaintext...), nil
 }

--- a/aes_aead_test.go
+++ b/aes_aead_test.go
@@ -1,0 +1,139 @@
+package wolfSSL
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"testing"
+)
+
+// Verify AesGcmAEAD satisfies cipher.AEAD at compile time.
+var _ cipher.AEAD = (*AesGcmAEAD)(nil)
+
+func TestAesGcmAEAD_NonceAndOverhead(t *testing.T) {
+	var key [AES_256_KEY_SIZE]byte
+	a := NewAesGcmAEAD(key)
+
+	if a.NonceSize() != AES_IV_SIZE {
+		t.Fatalf("NonceSize() = %d, want %d", a.NonceSize(), AES_IV_SIZE)
+	}
+	if a.Overhead() != AES_BLOCK_SIZE {
+		t.Fatalf("Overhead() = %d, want %d", a.Overhead(), AES_BLOCK_SIZE)
+	}
+}
+
+func TestAesGcmAEAD_SealOpen_RoundTrip(t *testing.T) {
+	var key [AES_256_KEY_SIZE]byte
+	for i := range key {
+		key[i] = byte(i)
+	}
+	a := NewAesGcmAEAD(key)
+
+	nonce := make([]byte, a.NonceSize())
+	for i := range nonce {
+		nonce[i] = byte(i + 100)
+	}
+
+	plaintext := []byte("Hello, wolfCrypt AES-GCM AEAD!")
+
+	ciphertext := a.Seal(nil, nonce, plaintext, nil)
+
+	// ciphertext should be len(plaintext) + Overhead
+	expectedLen := len(plaintext) + a.Overhead()
+	if len(ciphertext) != expectedLen {
+		t.Fatalf("Seal: ciphertext len = %d, want %d", len(ciphertext), expectedLen)
+	}
+
+	// ciphertext should differ from plaintext
+	if bytes.Equal(ciphertext[:len(plaintext)], plaintext) {
+		t.Fatal("Seal: ciphertext matches plaintext (encryption did nothing)")
+	}
+
+	decrypted, err := a.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Fatalf("Open: got %q, want %q", decrypted, plaintext)
+	}
+}
+
+func TestAesGcmAEAD_SealOpen_WithAAD(t *testing.T) {
+	var key [AES_256_KEY_SIZE]byte
+	for i := range key {
+		key[i] = byte(i * 3)
+	}
+	a := NewAesGcmAEAD(key)
+
+	nonce := make([]byte, a.NonceSize())
+	plaintext := []byte("authenticated additional data test")
+	aad := []byte("this is additional data")
+
+	ciphertext := a.Seal(nil, nonce, plaintext, aad)
+
+	// Decrypt with correct AAD
+	decrypted, err := a.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		t.Fatalf("Open with correct AAD: %v", err)
+	}
+	if !bytes.Equal(decrypted, plaintext) {
+		t.Fatalf("Open: got %q, want %q", decrypted, plaintext)
+	}
+
+	// Decrypt with wrong AAD should fail
+	_, err = a.Open(nil, nonce, ciphertext, []byte("wrong aad"))
+	if err == nil {
+		t.Fatal("Open with wrong AAD should have failed")
+	}
+}
+
+func TestAesGcmAEAD_SealOpen_EmptyPlaintext(t *testing.T) {
+	var key [AES_256_KEY_SIZE]byte
+	key[0] = 0x42
+	a := NewAesGcmAEAD(key)
+
+	nonce := make([]byte, a.NonceSize())
+	plaintext := []byte{}
+
+	ciphertext := a.Seal(nil, nonce, plaintext, nil)
+	if len(ciphertext) != a.Overhead() {
+		t.Fatalf("Seal empty: ciphertext len = %d, want %d (tag only)", len(ciphertext), a.Overhead())
+	}
+
+	decrypted, err := a.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		t.Fatalf("Open empty: %v", err)
+	}
+	if len(decrypted) != 0 {
+		t.Fatalf("Open empty: got %d bytes, want 0", len(decrypted))
+	}
+}
+
+func TestAesGcmAEAD_DstAppend(t *testing.T) {
+	var key [AES_256_KEY_SIZE]byte
+	key[1] = 0xFF
+	a := NewAesGcmAEAD(key)
+
+	nonce := make([]byte, a.NonceSize())
+	plaintext := []byte("dst append test")
+
+	// Seal with non-nil dst prefix
+	prefix := []byte("PREFIX:")
+	ciphertext := a.Seal(prefix, nonce, plaintext, nil)
+	if !bytes.HasPrefix(ciphertext, prefix) {
+		t.Fatal("Seal: result should start with dst prefix")
+	}
+
+	// Strip prefix, Open with non-nil dst prefix
+	ct := ciphertext[len(prefix):]
+	outPrefix := []byte("OUT:")
+	decrypted, err := a.Open(outPrefix, nonce, ct, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !bytes.HasPrefix(decrypted, outPrefix) {
+		t.Fatal("Open: result should start with dst prefix")
+	}
+	if !bytes.Equal(decrypted[len(outPrefix):], plaintext) {
+		t.Fatalf("Open: got %q, want %q", decrypted[len(outPrefix):], plaintext)
+	}
+}

--- a/ecc.go
+++ b/ecc.go
@@ -50,6 +50,28 @@ package wolfSSL
 //      return -174;
 //  }
 // #endif
+//
+// /* Negate an ECC private key: d' = order - d, then regenerate the public key.
+// #if defined(HAVE_ECC) && defined(WOLFSSL_PUBLIC_MP)
+// static int wc_ecc_negate_private(ecc_key* key) {
+//     mp_int order;
+//     int ret;
+//     ret = mp_init(&order);
+//     if (ret != 0) return ret;
+//     ret = mp_read_radix(&order, key->dp->order, MP_RADIX_HEX);
+//     if (ret == 0)
+//         ret = mp_sub(&order, wc_ecc_key_get_priv(key),
+//                      wc_ecc_key_get_priv(key));
+//     mp_clear(&order);
+//     if (ret == 0)
+//         ret = wc_ecc_make_pub(key, NULL);
+//     return ret;
+// }
+// #else
+// static int wc_ecc_negate_private(ecc_key* key) {
+//     (void)key; return -174;
+// }
+// #endif
 import "C"
 import (
     "unsafe"
@@ -187,4 +209,8 @@ func Wc_EccPublicKeyDecode(pubKey []byte, idx *int, key *C.struct_ecc_key, pubSz
     ret := int(C.wc_EccPublicKeyDecode((*C.uchar)(unsafe.Pointer(&pubKey[0])), &cIdx, key, C.word32(pubSz)))
     *idx = int(cIdx)
     return ret
+}
+
+func Wc_ecc_negate_private(key *C.struct_ecc_key) int {
+    return int(C.wc_ecc_negate_private(key))
 }

--- a/ecc.go
+++ b/ecc.go
@@ -51,7 +51,7 @@ package wolfSSL
 //  }
 // #endif
 //
-// /* Negate an ECC private key: d' = order - d, then regenerate the public key.
+// /* Negate an ECC private key: d' = order - d, then regenerate the public key */
 // #if defined(HAVE_ECC) && defined(WOLFSSL_PUBLIC_MP)
 // static int wc_ecc_negate_private(ecc_key* key) {
 //     mp_int order;


### PR DESCRIPTION
Add an AesGcmAEAD wrapper for crypto/cipher.AEAD compatability and testing for it. Also adds an ECC helper function  that's useful for an upcoming osp port