### PR TITLE
Fenrir fixes and test addition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,33 +38,45 @@ jobs:
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y autoconf automake libtool
 
-      - name: Cache wolfSSL build
+      - name: Cache wolfSSL builds
         id: cache-wolfssl
         uses: actions/cache@v4
         with:
-          path: /tmp/wolfssl-install
+          path: |
+            /tmp/wolfssl-install-all
+            /tmp/wolfssl-install-default
           key: wolfssl-${{ runner.os }}-${{ hashFiles('.github/workflows/build.yml') }}
 
-      - name: Build native wolfSSL
+      - name: Build native wolfSSL (full + default configs, single clone)
         if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         run: |
           git clone --depth 1 https://github.com/wolfSSL/wolfssl.git /tmp/wolfssl
           cd /tmp/wolfssl
           ./autogen.sh
-          ./configure --prefix=/tmp/wolfssl-install ${{ matrix.wolfssl_configure }}
+          # Full-featured config — drives the build/vet/examples checks below.
+          ./configure --prefix=/tmp/wolfssl-install-all ${{ matrix.wolfssl_configure }}
+          make -j$(nproc)
+          make install
+          # Default config (plain ./configure),
+          # rebuilt from the same checkout to exercise the #ifdef stub paths.
+          make clean
+          ./configure --prefix=/tmp/wolfssl-install-default
           make -j$(nproc)
           make install
 
-      - name: Install wolfSSL system-wide
+      - name: Install wolfSSL (full config) system-wide
         run: |
-          sudo cp -r /tmp/wolfssl-install/lib/* /usr/local/lib/
-          sudo cp -r /tmp/wolfssl-install/include/* /usr/local/include/
+          sudo cp -r /tmp/wolfssl-install-all/lib/* /usr/local/lib/
+          sudo cp -r /tmp/wolfssl-install-all/include/* /usr/local/include/
           sudo ldconfig
 
       - name: Install Go dependencies
         run: |
           go get golang.org/x/term
           go mod tidy
+
+      - name: Generate options.go (full config)
+        run: ./generateOptions.sh /usr/local
 
       - name: Build go-wolfssl library
         run: go build .
@@ -85,6 +97,38 @@ jobs:
             echo "Building $f..."
             go build "$f"
           done
+
+      - name: Run wolftls tests (full config)
+        run: go test ./wolftls
+
+      - name: Run wolfx509 tests (full config)
+        run: go test ./wolfx509
+
+      # ---- Default-config phase: validate the #ifdef stub paths against
+      # a plain ./configure wolfSSL
+      - name: Install wolfSSL (default config) system-wide
+        run: |
+          sudo rm -rf /usr/local/include/wolfssl
+          sudo cp -r /tmp/wolfssl-install-default/include/* /usr/local/include/
+          sudo cp -r /tmp/wolfssl-install-default/lib/* /usr/local/lib/
+          sudo ldconfig
+
+      - name: Generate options.go (default config)
+        # Re-point options.go at the default-config options.h so the wrapper
+        # and library agree on which features are compiled in.
+        run: ./generateOptions.sh /usr/local
+
+      - name: Clear Go build cache
+        # The cgo objects above were compiled against the full-config headers;
+        # Go's build cache does not track system headers, so clear it to force
+        # recompilation against the default-config options.h.
+        run: go clean -cache
+
+      - name: Run go vet (default config)
+        run: go vet .
+
+      - name: Run handles tests (default config)
+        run: go test ./handles
 
       - name: Show logs on failure
         if: failure() || cancelled()

--- a/ssl.go
+++ b/ssl.go
@@ -382,6 +382,12 @@ func WolfSSL_CTX_UseSNI(ctx *C.struct_WOLFSSL_CTX, sniType int, data []byte, siz
                unsafe.Pointer(&data[0]), C.ushort(size)))
 }
 
+func WolfSSL_check_domain_name(ssl *C.struct_WOLFSSL, dn string) int {
+    cDN := C.CString(dn)
+    defer C.free(unsafe.Pointer(cDN))
+    return int(C.wolfSSL_check_domain_name(ssl, cDN))
+}
+
 func WolfSSL_UseALPN(ssl *C.struct_WOLFSSL, protoList string, options int) int {
     c_list := C.CString(protoList)
     defer C.free(unsafe.Pointer(c_list))

--- a/ssl.go
+++ b/ssl.go
@@ -109,6 +109,24 @@ package wolfSSL
 //      return 0;
 // }
 // #endif
+// #ifndef HAVE_ALPN
+// int wolfSSL_UseALPN(WOLFSSL* ssl, char* protocol_name_list,
+//                     unsigned int protocol_name_listSz, unsigned char options) {
+//      (void)ssl; (void)protocol_name_list; (void)protocol_name_listSz;
+//      (void)options; return -174;
+// }
+// int wolfSSL_ALPN_GetProtocol(WOLFSSL* ssl, char** protocol_name,
+//                              unsigned short* size) {
+//      (void)ssl; (void)protocol_name; (void)size; return -174;
+// }
+// int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char** list,
+//                                  unsigned short* listSz) {
+//      (void)ssl; (void)list; (void)listSz; return -174;
+// }
+// int wolfSSL_ALPN_FreePeerProtocol(WOLFSSL* ssl, char** list) {
+//      (void)ssl; (void)list; return -174;
+// }
+// #endif
 import "C"
 import (
     "unsafe"

--- a/wolftls/conn.go
+++ b/wolftls/conn.go
@@ -357,6 +357,16 @@ func (c *Conn) doHandshake() error {
 		}
 	}
 
+	// Bind the expected hostname so wolfSSL checks the server leaf
+	// certificate's SAN/CN against it during the handshake
+	if c.isClient && c.config.ServerName != "" && !c.config.InsecureSkipVerify {
+		ret := wolfSSL.WolfSSL_check_domain_name(c.ssl, c.config.ServerName)
+		if ret != wolfSSL.WOLFSSL_SUCCESS {
+			c.freeSSL()
+			return fmt.Errorf("wolftls: failed to set domain name check (%d)", ret)
+		}
+	}
+
 	// Set ALPN
 	if len(c.config.NextProtos) > 0 {
 		// wolfSSL expects a comma-separated list

--- a/wolftls/conn.go
+++ b/wolftls/conn.go
@@ -432,7 +432,17 @@ func (c *Conn) cleanup() {
 // buildConnectionState populates c.connState from the wolfSSL session.
 func (c *Conn) buildConnectionState() error {
 	c.connState.HandshakeComplete = true
-	c.connState.ServerName = c.config.ServerName
+	if c.isClient {
+		// Client: SNI is what we sent; mirror the value from config.
+		c.connState.ServerName = c.config.ServerName
+	} else {
+		// Server: SNI is what the client sent in its ClientHello; query
+		// the wolfSSL session. Required for server-side dispatch logic
+		// that reads ConnectionState().ServerName (e.g., net/http's
+		// r.TLS.ServerName, which downstream handlers use for per-host
+		// routing).
+		c.connState.ServerName = wolfSSL.WolfSSL_SNI_GetServerName(c.ssl)
+	}
 
 	// TLS version
 	versionStr := wolfSSL.WolfSSL_get_version(c.ssl)

--- a/wolftls/conn.go
+++ b/wolftls/conn.go
@@ -164,6 +164,11 @@ func (c *Conn) HandshakeContext(ctx context.Context) error {
 
 // doHandshake performs the actual handshake. Must be called with handshakeMu held.
 func (c *Conn) doHandshake() error {
+	// Reject a ServerName containing a NUL byte
+	if strings.IndexByte(c.config.ServerName, 0) >= 0 {
+		return errors.New("wolftls: ServerName contains NUL byte")
+	}
+
 	// Create CTX with version-flexible method
 	if c.isClient {
 		c.ctx = wolfSSL.WolfSSL_CTX_new_v23_client()

--- a/wolftls/tls_test.go
+++ b/wolftls/tls_test.go
@@ -433,7 +433,7 @@ func TestRootCAPEMsVerification(t *testing.T) {
 
 	// Client with CA loaded — wolfSSL should verify the server cert
 	clientConfig := &Config{
-		ServerName:         "localhost",
+		ServerName:         "example.com",
 		InsecureSkipVerify: false,
 		RootCAPEMs:         [][]byte{caPEM},
 	}
@@ -523,6 +523,61 @@ func TestRootCAPEMsRejectsWrongCA(t *testing.T) {
 	t.Logf("expected handshake failure: %v", err)
 
 	// Server side may also error — that's fine
+	<-errc
+}
+
+func TestVerifyHostnameMismatch(t *testing.T) {
+	certPEM := loadFile(t, certPath("server-cert.pem"))
+	keyPEM := loadFile(t, certPath("server-key.pem"))
+	caPEM := loadFile(t, certPath("ca-cert.pem"))
+
+	serverConfig := &Config{
+		Certificates: []Certificate{{
+			CertPEM: certPEM,
+			KeyPEM:  keyPEM,
+		}},
+	}
+
+	// Trusted chain (CA loaded), but ServerName is not in the cert's SAN
+	// (which only covers example.com / 127.0.0.1).
+	clientConfig := &Config{
+		ServerName:         "test.example.com",
+		InsecureSkipVerify: false,
+		RootCAPEMs:         [][]byte{caPEM},
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errc := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			errc <- err
+			return
+		}
+		tlsConn := Server(conn, serverConfig)
+		defer tlsConn.Close()
+		errc <- tlsConn.Handshake()
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	tlsConn := Client(conn, clientConfig)
+	defer tlsConn.Close()
+
+	if err := tlsConn.Handshake(); err == nil {
+		t.Fatal("handshake should fail: cert SAN does not cover ServerName")
+	} else {
+		t.Logf("expected hostname-mismatch failure: %v", err)
+	}
+
+	// Server side may also error from the client's alert — that's fine.
 	<-errc
 }
 

--- a/wolftls/tls_test.go
+++ b/wolftls/tls_test.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -571,11 +572,16 @@ func TestVerifyHostnameMismatch(t *testing.T) {
 	tlsConn := Client(conn, clientConfig)
 	defer tlsConn.Close()
 
-	if err := tlsConn.Handshake(); err == nil {
+	err = tlsConn.Handshake()
+	if err == nil {
 		t.Fatal("handshake should fail: cert SAN does not cover ServerName")
-	} else {
-		t.Logf("expected hostname-mismatch failure: %v", err)
 	}
+	// Assert the failure is the hostname check rejecting the leaf cert
+	// during the handshake
+	if !strings.Contains(err.Error(), "-322") {
+		t.Fatalf("expected DOMAIN_NAME_MISMATCH (-322) hostname-verification failure, got: %v", err)
+	}
+	t.Logf("expected hostname-mismatch failure: %v", err)
 
 	// Server side may also error from the client's alert — that's fine.
 	<-errc

--- a/x509.go
+++ b/x509.go
@@ -114,15 +114,35 @@ package wolfSSL
 // }
 // #else
 // static int wolfx509_asn1_time_print(const WOLFSSL_ASN1_TIME* t, char* out, int outSz) { (void)t; (void)out; (void)outSz; return 0; }
-// static char* wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME* name, char* in, int sz) { (void)name; (void)in; (void)sz; return NULL; }
+// char* wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME* name, char* in, int sz) { (void)name; (void)in; (void)sz; return NULL; }
 // static int wolfx509_name_get_text_by_nid(WOLFSSL_X509_NAME* name, int nid, char* out, int outSz) { (void)name; (void)nid; (void)out; (void)outSz; return 0; }
-// static char* wolfSSL_X509_get_subjectCN(WOLFSSL_X509* x) { (void)x; return NULL; }
+// char* wolfSSL_X509_get_subjectCN(WOLFSSL_X509* x) { (void)x; return NULL; }
 // static int wolfx509_get_serial_bytes(WOLFSSL_X509* x, unsigned char* out, int outSz) { (void)x; (void)out; (void)outSz; return 0; }
 // static int wolfx509_get_authority_key_id(WOLFSSL_X509* x, unsigned char* out, int outSz) { (void)x; (void)out; (void)outSz; return 0; }
 // static WOLFSSL_X509_NAME* wolfSSL_X509_get_subject_name(WOLFSSL_X509* cert) { (void)cert; return NULL; }
 // static WOLFSSL_X509_NAME* wolfSSL_X509_get_issuer_name(WOLFSSL_X509* cert) { (void)cert; return NULL; }
 // static WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notBefore(const WOLFSSL_X509* x) { (void)x; return NULL; }
 // static WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notAfter(const WOLFSSL_X509* x) { (void)x; return NULL; }
+// #endif
+// #ifndef KEEP_PEER_CERT
+// WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl) { (void)ssl; return NULL; }
+// #endif
+// #if !defined(OPENSSL_EXTRA) && !defined(WOLFSSL_WPAS_SMALL) && \
+//     !defined(KEEP_OUR_CERT) && !defined(KEEP_PEER_CERT) && !defined(SESSION_CERTS)
+// const unsigned char* wolfSSL_X509_get_der(WOLFSSL_X509* x509, int* outSz) {
+//     (void)x509; (void)outSz; return NULL;
+// }
+// #endif
+// #if !defined(KEEP_PEER_CERT) && !defined(SESSION_CERTS) && \
+//     !defined(OPENSSL_EXTRA) && !defined(OPENSSL_EXTRA_X509_SMALL)
+// WOLFSSL_X509* wolfSSL_d2i_X509(WOLFSSL_X509** x509, const unsigned char** in, int len) {
+//     (void)x509; (void)in; (void)len; return NULL;
+// }
+// #endif
+// #ifndef OPENSSL_EXTRA
+// int wolfSSL_i2d_X509(WOLFSSL_X509* x509, unsigned char** out) {
+//     (void)x509; (void)out; return -174;
+// }
 // #endif
 // #include <string.h>
 import "C"


### PR DESCRIPTION
  ### Server-side SNI - Fenrir 3521 (2d965e6)
  - buildConnectionState now distinguishes client vs. server when populating ConnectionState.ServerName. Clients mirror the configured SNI; servers query the wolfSSL session via WolfSSL_SNI_GetServerName to expose the name the
  client sent in its ClientHello. 
  
  ### Hostname verification - Fenrir 3522 (95c55f7)
  - New WolfSSL_check_domain_name wrapper in ssl.go.
  - During the client handshake, wolftls now binds the expected hostname so wolfSSL validates the server leaf certificate's SAN/CN against config.ServerName (skipped when InsecureSkipVerify is set). A mismatch fails the
  handshake.
  - Tests: added TestVerifyHostnameMismatch (trusted chain but ServerName outside the cert SAN → handshake fails); updated TestRootCAPEMsVerification to use a SAN-covered name (example.com).
  
  ### Missing ALPN & X509 stubs (a61a69d)
  - Added stub functions under the appropriate #ifdef/#ifndef guards so the package builds against a minimal wolfSSL config:
    - ALPN (#ifndef HAVE_ALPN): wolfSSL_UseALPN, wolfSSL_ALPN_GetProtocol, wolfSSL_ALPN_GetPeerProtocol, wolfSSL_ALPN_FreePeerProtocol.
    - X509: wolfSSL_get_peer_certificate (KEEP_PEER_CERT), wolfSSL_X509_get_der, wolfSSL_d2i_X509, wolfSSL_i2d_X509 (OPENSSL_EXTRA).
  - Made wolfSSL_X509_NAME_oneline and wolfSSL_X509_get_subjectCN non-static to match their real wolfSSL linkage.

  ### CI: exercise default config + tls/x509 (baee231)
  - Builds wolfSSL twice from a single clone: the full --enable-all config (drives build/vet/examples) and a plain ./configure default config (exercises the #ifdef stub paths).
  - Runs wolftls and wolfx509 tests against the full config.
  - Adds a default-config phase that re-installs the default build, regenerates options.go, clears the Go build cache (cgo objects don't track system header changes), then runs go vet and the handles tests.