### PR TITLE
FIPS compatibility improvements and build/test fixes

### DIFF
--- a/aes.go
+++ b/aes.go
@@ -274,7 +274,10 @@ func Wc_PBKDF2(out []byte, pwd []byte, pLen int, salt []byte, saltLen int, iter 
     if len(salt) > 0 {
         saltPtr = (*C.uchar)(unsafe.Pointer(&salt[0]))
     }
-    return int(C.wc_PBKDF2(outPtr, pwdPtr, C.int(pLen),
+    PRIVATE_KEY_UNLOCK()
+    ret := int(C.wc_PBKDF2(outPtr, pwdPtr, C.int(pLen),
                saltPtr, C.int(saltLen), C.int(iter), C.int(kLen), C.int(typeH)))
+    PRIVATE_KEY_LOCK()
+    return ret
 }
 

--- a/ecc.go
+++ b/ecc.go
@@ -108,12 +108,17 @@ package wolfSSL
 // static int wc_ecc_negate_private(ecc_key* key) {
 //     mp_int order;
 //     int ret;
+//     mp_int* priv;
+// #ifdef WOLFSSL_HAVE_ECC_KEY_GET_PRIV
+//     priv = wc_ecc_key_get_priv(key);
+// #else
+//     priv = &key->k;
+// #endif
 //     ret = mp_init(&order);
 //     if (ret != 0) return ret;
 //     ret = mp_read_radix(&order, key->dp->order, MP_RADIX_HEX);
 //     if (ret == 0)
-//         ret = mp_sub(&order, wc_ecc_key_get_priv(key),
-//                      wc_ecc_key_get_priv(key));
+//         ret = mp_sub(&order, priv, priv);
 //     mp_clear(&order);
 //     if (ret == 0)
 //         ret = wc_ecc_make_pub(key, NULL);

--- a/ecc.go
+++ b/ecc.go
@@ -160,8 +160,10 @@ func Wc_ecc_export_private_only(key *C.struct_ecc_key, out []byte, outLen *int) 
         return BAD_FUNC_ARG
     }
     cOutLen := C.word32(*outLen)
+    PRIVATE_KEY_UNLOCK()
     ret := int(C.wc_ecc_export_private_only(key, (*C.byte)(unsafe.Pointer(&out[0])), &cOutLen))
     *outLen = int(cOutLen)
+    PRIVATE_KEY_LOCK()
     return ret
 }
 
@@ -170,8 +172,10 @@ func Wc_ecc_export_x963_ex(key *C.struct_ecc_key, out []byte, outLen *int, compr
         return BAD_FUNC_ARG
     }
     cOutLen := C.word32(*outLen)
+    PRIVATE_KEY_UNLOCK()
     ret := int(C.wc_ecc_export_x963_ex(key, (*C.byte)(unsafe.Pointer(&out[0])), &cOutLen, C.int(compressed)))
     *outLen = int(cOutLen)
+    PRIVATE_KEY_LOCK()
     return ret
 }
 
@@ -245,8 +249,10 @@ func Wc_ecc_shared_secret(privKey, pubKey *C.struct_ecc_key, out []byte, outLen 
         return BAD_FUNC_ARG
     }
     cOutLen := C.word32(*outLen)
+    PRIVATE_KEY_UNLOCK()
     ret := int(C.wc_ecc_shared_secret(privKey, pubKey, (*C.uchar)(unsafe.Pointer(&out[0])), &cOutLen))
     *outLen = int(cOutLen)
+    PRIVATE_KEY_LOCK()
     return ret
 }
 

--- a/fips.go
+++ b/fips.go
@@ -44,8 +44,8 @@ package wolfSSL
 //    printf("hash = %s\n", hash);
 //
 //    if (err == -203) {
-//        printf("In core integrity hash check failure, copy above hash\n");
-//        printf("into verifyCore[] in fips_test.c and rebuild\n");
+//        printf("In-core integrity hash check failure, copy above hash\n");
+//        printf("into verifyCore[] in wolfssl/wolfcrypt/src/fips_test.c and rebuild\n");
 //    }
 // }
 // void wc_SetDefaultFips_Cb(void) {
@@ -85,4 +85,9 @@ func PRIVATE_KEY_UNLOCK() int {
 
 func Wc_RunAllCast_fips() int {
     return int(C.wc_RunAllCast_fips())
+}
+
+func init() {
+    Wc_SetDefaultFips_Cb()
+    Wc_SetDefaultSeed_Cb()
 }

--- a/hmac.go
+++ b/hmac.go
@@ -119,9 +119,12 @@ func Wc_HKDF(hashType int, inputKey []byte, inputKeySz int, salt []byte,
     if len(info) > 0 {
         infoPtr = (*C.uchar)(unsafe.Pointer(&info[0]))
     }
-    return int(C.wc_HKDF(C.int(hashType), ikmPtr,
+    PRIVATE_KEY_UNLOCK()
+    ret := int(C.wc_HKDF(C.int(hashType), ikmPtr,
                C.word32(inputKeySz), saltPtr,
                C.word32(saltSz), infoPtr,
                C.word32(infoSz), (*C.uchar)(unsafe.Pointer(&out[0])),
                C.word32(outSz)))
+    PRIVATE_KEY_LOCK()
+    return ret
 }

--- a/wolftls/callbacks.go
+++ b/wolftls/callbacks.go
@@ -68,20 +68,20 @@ package wolftls
 //
 // /* Helpers that take the trampoline addresses without exposing Go to
 //  * the C function-pointer types (which cgo can't always represent). */
-// static void wolftls_set_io_recv(WOLFSSL_CTX* ctx) {
+// static inline void wolftls_set_io_recv(WOLFSSL_CTX* ctx) {
 //     wolfSSL_CTX_SetIORecv(ctx, ioRecvTrampoline);
 // }
-// static void wolftls_set_io_send(WOLFSSL_CTX* ctx) {
+// static inline void wolftls_set_io_send(WOLFSSL_CTX* ctx) {
 //     wolfSSL_CTX_SetIOSend(ctx, ioSendTrampoline);
 // }
 // #ifdef HAVE_SNI
-// static void wolftls_set_sni_cb(WOLFSSL_CTX* ctx, int connID) {
+// static inline void wolftls_set_sni_cb(WOLFSSL_CTX* ctx, int connID) {
 //     wolfSSL_CTX_set_servername_callback(ctx, (CallbackSniRecv)sniTrampoline);
 //     wolfSSL_CTX_set_servername_arg(ctx, (void*)(intptr_t)connID);
 // }
 // #endif
 // #ifdef WOLFSSL_CERT_SETUP_CB
-// static void wolftls_set_cert_cb(WOLFSSL_CTX* ctx, int connID) {
+// static inline void wolftls_set_cert_cb(WOLFSSL_CTX* ctx, int connID) {
 //     wolfSSL_CTX_set_cert_cb(ctx, certSetupTrampoline,
 //                              (void*)(intptr_t)connID);
 // }
@@ -89,7 +89,7 @@ package wolftls
 // /* Stub for vanilla wolfSSL builds without WOLFSSL_CERT_SETUP_CB.
 //  * wolftls.Conn's per-connection GetCertificate callback is unavailable
 //  * in this build mode; ctxSetCertSetupCallback becomes a no-op. */
-// static void wolftls_set_cert_cb(WOLFSSL_CTX* ctx, int connID) {
+// static inline void wolftls_set_cert_cb(WOLFSSL_CTX* ctx, int connID) {
 //     (void)ctx; (void)connID;
 // }
 // #endif

--- a/wolftls/tls_test.go
+++ b/wolftls/tls_test.go
@@ -1018,7 +1018,7 @@ func setupPair(t *testing.T) (client *Conn, server *Conn, cleanup func()) {
 		ln.Close()
 		t.Fatalf("dial: %v", err)
 	}
-	ln.Close()
+	defer ln.Close()
 
 	cli := Client(conn, clientConfig)
 	if err := cli.Handshake(); err != nil {


### PR DESCRIPTION
  FIPS private-key locking/unlocking

  - Wrap PRIVATE_KEY_UNLOCK() / PRIVATE_KEY_LOCK() around wrapper functions that read or derive private key material, so they work correctly under FIPS builds where the private key region
  is locked by default:
    - aes.go: Wc_PBKDF2
    - hmac.go: Wc_HKDF
    - ecc.go: Wc_ecc_export_private_only, Wc_ecc_export_x963_ex, Wc_ecc_shared_secret

  Automatic default FIPS Seed and Callback

  - Add a package init() in fips.go that calls Wc_SetDefaultFips_Cb() and Wc_SetDefaultSeed_Cb(), so consumers get sensible FIPS defaults without manual setup.

  Older wolfSSL compatibility fixes

  - ecc.go: guard wc_ecc_key_get_priv() usage behind WOLFSSL_HAVE_ECC_KEY_GET_PRIV, falling back to &key->k on older versions that lack the accessor.
  - wolftls/callbacks.go: mark the static C trampoline helpers inline to avoid unused-function warnings/errors across compilers.

  Test fix

  - wolftls/tls_test.go: defer ln.Close() in setupPair instead of closing the listener immediately, fixing an early socket close that could race the handshake.